### PR TITLE
modify ancestor name

### DIFF
--- a/adapter/gateway/prompt_inputter.go
+++ b/adapter/gateway/prompt_inputter.go
@@ -223,7 +223,7 @@ func (i *fieldInputter) inputField(field entity.Field) error {
 		setter := protobuf.NewMessageSetter(f)
 		fields := f.Fields()
 
-		msg, err := newFieldInputter(i.prompt, i.prefixFormat, setter, append(i.ancestor, f.Name()), true, i.color).Input(fields)
+		msg, err := newFieldInputter(i.prompt, i.prefixFormat, setter, append(i.ancestor, f.FieldName()), true, i.color).Input(fields)
 		if err != nil {
 			return err
 		}

--- a/adapter/gateway/prompt_inputter.go
+++ b/adapter/gateway/prompt_inputter.go
@@ -101,7 +101,7 @@ type fieldInputter struct {
 	enteredEmptyInput bool
 
 	// the field has parent field (in other words, the field is child of a message field)
-	hasParentAndItIsRepeatedField bool
+	hasAncestorAndHasRepeatedField bool
 }
 
 func newFieldInputter(
@@ -109,7 +109,7 @@ func newFieldInputter(
 	prefixFormat string,
 	setter *protobuf.MessageSetter,
 	ancestor []string,
-	hasParentAndItIsRepeatedField bool,
+	hasAncestorAndHasRepeatedField bool,
 	color prompt.Color,
 ) *fieldInputter {
 	return &fieldInputter{
@@ -118,7 +118,7 @@ func newFieldInputter(
 		prefixFormat: prefixFormat,
 		ancestor:     ancestor,
 		color:        color,
-		hasParentAndItIsRepeatedField: hasParentAndItIsRepeatedField,
+		hasAncestorAndHasRepeatedField: hasAncestorAndHasRepeatedField,
 	}
 }
 
@@ -223,8 +223,7 @@ func (i *fieldInputter) inputField(field entity.Field) error {
 		setter := protobuf.NewMessageSetter(f)
 		fields := f.Fields()
 
-		// msg, err := newFieldInputter(i.prompt, i.prefixFormat, setter, append(i.ancestor, f.FieldName()), f.IsRepeated(), i.color).Input(fields)
-		msg, err := newFieldInputter(i.prompt, i.prefixFormat, setter, append(i.ancestor, f.FieldName()), true, i.color).Input(fields)
+		msg, err := newFieldInputter(i.prompt, i.prefixFormat, setter, append(i.ancestor, f.FieldName()), i.hasAncestorAndHasRepeatedField || f.IsRepeated(), i.color).Input(fields)
 		if err != nil {
 			return err
 		}
@@ -255,8 +254,8 @@ func (i *fieldInputter) inputPrimitiveField(f entity.PrimitiveField) (interface{
 
 	if in == "" {
 		// if f is repeated or
-		// the parent field of f is repeated field
-		if f.IsRepeated() || i.hasParentAndItIsRepeatedField {
+		// ancestor has repeated field
+		if f.IsRepeated() || i.hasAncestorAndHasRepeatedField {
 			if i.enteredEmptyInput {
 				return nil, EORF
 			}
@@ -273,30 +272,26 @@ func (i *fieldInputter) inputPrimitiveField(f entity.PrimitiveField) (interface{
 
 // makePrefix makes prefix for field f.
 func (i *fieldInputter) makePrefix(f entity.PrimitiveField) string {
-	return makePrefix(i.prefixFormat, f, i.ancestor, i.hasParentAndItIsRepeatedField)
+	return makePrefix(i.prefixFormat, f, i.ancestor, i.hasAncestorAndHasRepeatedField)
 }
 
 const (
-	repeatedStr       = " <repeated>"
+	repeatedStr       = "<repeated> "
 	ancestorDelimiter = "::"
 )
 
-func makePrefix(s string, f entity.PrimitiveField, ancestor []string, parentIsRepeated bool) string {
+func makePrefix(s string, f entity.PrimitiveField, ancestor []string, ancestorHasRepeated bool) string {
 	joinedAncestor := strings.Join(ancestor, ancestorDelimiter)
-	if parentIsRepeated {
-		joinedAncestor += repeatedStr
-	}
 	if joinedAncestor != "" {
 		joinedAncestor += ancestorDelimiter
 	}
 
-	name := f.FieldName()
-	if f.IsRepeated() {
-		name += repeatedStr
-	}
-
 	s = strings.Replace(s, "{ancestor}", joinedAncestor, -1)
-	s = strings.Replace(s, "{name}", name, -1)
+	s = strings.Replace(s, "{name}", f.FieldName(), -1)
 	s = strings.Replace(s, "{type}", f.PBType(), -1)
+
+	if f.IsRepeated() || ancestorHasRepeated {
+		return repeatedStr + s
+	}
 	return s
 }

--- a/adapter/gateway/prompt_inputter_test.go
+++ b/adapter/gateway/prompt_inputter_test.go
@@ -243,14 +243,21 @@ func Test_makePrefix(t *testing.T) {
 	f := testentity.NewFld()
 	t.Run("primitive", func(t *testing.T) {
 		expected := fmt.Sprintf("%s (%s)", f.FieldName(), f.PBType())
-		actual := makePrefix(prefix, f, nil)
+		actual := makePrefix(prefix, f, nil, false)
 
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("nested", func(t *testing.T) {
 		expected := fmt.Sprintf("Foo::Bar::%s (%s)", f.FieldName(), f.PBType())
-		actual := makePrefix(prefix, f, []string{"Foo", "Bar"})
+		actual := makePrefix(prefix, f, []string{"Foo", "Bar"}, false)
 		require.Equal(t, expected, actual)
+	})
+
+	t.Run("repeated (field)", func(t *testing.T) {
+		expected := fmt.Sprintf("Foo::Bar::%s <repeated> (%s)", f.FieldName(), f.PBType())
+		f.FIsRepeated = true
+		actual := makePrefix(prefix, f, []string{"Foo", "Bar"}, false)
+		require.Equal(t, expected, actual, false)
 	})
 }

--- a/entity/testentity/stub.go
+++ b/entity/testentity/stub.go
@@ -22,29 +22,35 @@ func newName() string {
 type Fld struct {
 	entity.Field
 
-	name      string
-	fieldName string
-	pbtype    string
+	FName       string
+	FFieldName  string
+	FPBtype     string
+	FIsRepeated bool
 }
 
 func NewFld() *Fld {
 	return &Fld{
-		name:      newName(),
-		fieldName: newName(),
-		pbtype:    newName(),
+		FName:       newName(),
+		FFieldName:  newName(),
+		FPBtype:     newName(),
+		FIsRepeated: false,
 	}
 }
 
 func (f *Fld) Name() string {
-	return f.name
+	return f.FName
 }
 
 func (f *Fld) FieldName() string {
-	return f.fieldName
+	return f.FFieldName
 }
 
 func (f *Fld) PBType() string {
-	return f.pbtype
+	return f.FPBtype
+}
+
+func (f *Fld) IsRepeated() bool {
+	return f.FIsRepeated
 }
 
 type RPC struct {


### PR DESCRIPTION
- if an inputting field is repeated, show `<repeated>` string to prefix
- show field name instead of message name