### PR TITLE
accepts multi paths

### DIFF
--- a/adapter/controller/cli_test.go
+++ b/adapter/controller/cli_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ktr0731/evans/tests/helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLI(t *testing.T) {
+	t.Run("proto path (option)", func(t *testing.T) {
+		conf := helper.TestConfig()
+		opt := &Options{
+			Path: []string{"foo", "foo", "bar"},
+		}
+		paths, err := collectProtoPaths(conf, opt)
+		require.NoError(t, err)
+		require.Len(t, paths, 2)
+	})
+
+	t.Run("proto path (config)", func(t *testing.T) {
+		conf := helper.TestConfig()
+		conf.Default.ProtoPath = []string{"foo", "foo", "bar"}
+		opt := &Options{}
+		paths, err := collectProtoPaths(conf, opt)
+		require.NoError(t, err)
+		require.Len(t, paths, 2)
+	})
+
+	t.Run("proto path (both)", func(t *testing.T) {
+		conf := helper.TestConfig()
+		conf.Default.ProtoPath = []string{"foo", "foo", "bar"}
+		opt := &Options{
+			Path: []string{"foo", "baz", "bar"},
+		}
+		paths, err := collectProtoPaths(conf, opt)
+		require.NoError(t, err)
+		require.Len(t, paths, 3)
+	})
+
+	t.Run("proto path (from file)", func(t *testing.T) {
+		conf := helper.TestConfig()
+		opt := &Options{
+			Proto: []string{"./hoge", "./foo/bar"},
+		}
+		paths, err := collectProtoPaths(conf, opt)
+		require.NoError(t, err)
+		require.Len(t, paths, 2)
+		require.Exactly(t, []string{".", "foo"}, paths)
+	})
+
+	setEnv := func(k, v string) func() {
+		old := os.Getenv(k)
+		os.Setenv(k, v)
+		return func() {
+			os.Setenv(k, old)
+		}
+	}
+
+	t.Run("proto path (env)", func(t *testing.T) {
+		conf := helper.TestConfig()
+		opt := &Options{
+			Proto: []string{"$hoge/foo", "/fuga/bar"},
+		}
+
+		cleanup := setEnv("hoge", "/fuga")
+		defer cleanup()
+
+		paths, err := collectProtoPaths(conf, opt)
+		require.NoError(t, err)
+		require.Len(t, paths, 1)
+		require.Equal(t, "/fuga", paths[0])
+	})
+
+	t.Run("error/proto path", func(t *testing.T) {
+		conf := helper.TestConfig()
+		opt := &Options{
+			Proto: []string{"foo bar"},
+		}
+
+		_, err := collectProtoPaths(conf, opt)
+		require.Error(t, err)
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type Header struct {
 }
 
 type Request struct {
-	Header []Header `default:"foo" toml:"header"`
+	Header []Header `toml:"header"`
 }
 
 type REPL struct {
@@ -67,8 +67,9 @@ type Config struct {
 }
 
 type Default struct {
-	Package string `toml:"package" default:""`
-	Service string `toml:"service" default:""`
+	ProtoPath []string `toml:"protoPath" default:""`
+	Package   string   `toml:"package" default:""`
+	Service   string   `toml:"service" default:""`
 }
 
 type Log struct {
@@ -80,7 +81,17 @@ type localConfig struct {
 }
 
 func init() {
-	var conf Config
+	conf := Config{
+		Request: &Request{
+			Header: []Header{
+				{"user-agent", "evans"},
+			},
+		},
+		// to show items in initial config file, set an empty value
+		Default: &Default{
+			ProtoPath: []string{""},
+		},
+	}
 	var err error
 	if err := envconfig.Process("evans", &conf); err != nil {
 		panic(err)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 9b110fe65e53714f2e18f00a7d9b8e97181867975e8dc9fc06129dc7e64cdc4b
-updated: 2018-01-21T15:08:49.482810541+09:00
+updated: 2018-02-10T16:56:52.137823863+09:00
 imports:
 - name: github.com/AlecAivazis/survey
   version: f051d0d636f1be0261d8d320a4b2365e7ccd9888
@@ -55,6 +55,8 @@ imports:
   repo: https://github.com/mattn/go-isatty
 - name: github.com/mattn/go-runewidth
   version: 97311d9f7767e3d6f422ea06661bc2c7a19e8a5d
+- name: github.com/mattn/go-shellwords
+  version: 39dbbfa24bbc39559b61cae9b20b0e8db0e55525
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
 - name: github.com/mitchellh/go-homedir

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	name    = "evans"
-	version = "0.2.3"
+	version = "0.2.4"
 )
 
 func main() {


### PR DESCRIPTION
- [x] https://github.com/ktr0731/evans/issues/5
- [x] thanks to [mattn/go-shellwords](https://github.com/mattn/go-shellwords), can interpret envvars

``` sh
$ export GOPATH=/Users/foo/.ghq
```
``` toml
[default]
  protoPath = ["$GOPATH/src"] # "/Users/foo/.ghq/src"
```