### PR TITLE
Fix a panic caused by nil pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ deps: glide
 
 .PHONY: build
 build: deps
-	go build 
+	go build
 
 .PHONY: test
 test:
 	go test -race -v $(shell glide novendor)
 
 .PHONY: coverage
-coverage: 
+coverage:
 	go tool cover -html=coverage.out
 
 .PHONY: brew-update

--- a/adapter/controller/cli.go
+++ b/adapter/controller/cli.go
@@ -131,7 +131,7 @@ func (c *CLI) Run(args []string) int {
 		var err error
 		tag, err = update_checker.NewUpdateChecker().Check(ctx)
 		if err != nil {
-			tag.CurrentIsLatest = true
+			tag = &update_checker.ReleaseTag{CurrentIsLatest: true}
 		}
 	}()
 


### PR DESCRIPTION
I'm facing this panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x156b17a]

goroutine 19 [running]:
github.com/ktr0731/evans/adapter/controller.(*CLI).Run.func1(0xc42036a5d0, 0x1784000, 0xc4202f3400, 0xc4202f04b8)
        /path/to/go/src/github.com/ktr0731/evans/adapter/controller/cli.go:134 +0x7a
created by github.com/ktr0731/evans/adapter/controller.(*CLI).Run
        /path/to/go/src/github.com/ktr0731/evans/adapter/controller/cli.go:129 +0x3f9
```

and fixed it.