### PR TITLE
Remove the directory part from each proto file

### DIFF
--- a/adapter/internal/protoparser/parser.go
+++ b/adapter/internal/protoparser/parser.go
@@ -10,12 +10,18 @@ import (
 func ParseFile(fnames []string, paths []string) ([]*desc.FileDescriptor, error) {
 	encountered := map[string]bool{}
 	paths = append(paths, ".")
+	files := []string{}
 	encountered["."] = true
 	for _, path := range paths {
 		encountered[path] = true
 	}
 
 	for _, fname := range fnames {
+		_, file := filepath.Split(fname)
+		files = append(files, file)
+
+		// This is different from the result of filepath.Split above
+		// because it returns '.' if the path is empty.
 		path := filepath.Dir(fname)
 		if !encountered[path] {
 			paths = append(paths, path)
@@ -25,5 +31,5 @@ func ParseFile(fnames []string, paths []string) ([]*desc.FileDescriptor, error) 
 	p := &protoparse.Parser{
 		ImportPaths: paths,
 	}
-	return p.ParseFiles(fnames...)
+	return p.ParseFiles(files...)
 }


### PR DESCRIPTION
This code is adding the directory part to the search path. Since the parser
cannot tell the difference between <dir>/<file> and <file>, always use just the
name of the file.

This addresses issue #80