### PR TITLE
Add a flag to compact the build from CircleCI

### DIFF
--- a/.circleci/scripts/build-assets.bash
+++ b/.circleci/scripts/build-assets.bash
@@ -11,6 +11,6 @@ gox -osarch "$OSARCH" \
 
 for f in *; do
   mv "$f" evans
-  tar cvf "$f.tar.gz" evans
+  tar czvf "$f.tar.gz" evans
   rm -f evans
 done


### PR DESCRIPTION
Add a flag to compact the build from CircleCI, so the outpuz is a real .tar.gz
Closes #85 