### PR TITLE
vendor: use override instead of constraint for dep warning to k0kubun/pp

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@
   branch = "master"
   name = "github.com/jhump/protoreflect"
 
-[[constraint]]
+[[override]]
   name = "github.com/k0kubun/pp"
   version = "2.3.0"
 


### PR DESCRIPTION
Use override instead of constraint for dep warning to `k0kubun/pp` package vendering.

Here is the warning log:
```sh
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/k0kubun/pp
```