### PR TITLE
Emit default values to an output string

### DIFF
--- a/adapter/presenter/cli.go
+++ b/adapter/presenter/cli.go
@@ -73,7 +73,7 @@ func (m *jsonMarshaler) Marshal(out io.Writer, pb proto.Message) error {
 		var b []byte
 		var err error
 		if m.hasIndent() {
-			b, err = dmsg.MarshalJSONIndent()
+			b, err = dmsg.MarshalJSONPB(&jsonpb.Marshaler{Indent: "  ", EmitDefaults: true})
 		} else {
 			b, err = dmsg.MarshalJSON()
 		}

--- a/adapter/presenter/cli.go
+++ b/adapter/presenter/cli.go
@@ -73,7 +73,10 @@ func (m *jsonMarshaler) Marshal(out io.Writer, pb proto.Message) error {
 		var b []byte
 		var err error
 		if m.hasIndent() {
-			b, err = dmsg.MarshalJSONPB(&jsonpb.Marshaler{Indent: "  ", EmitDefaults: true})
+			b, err = dmsg.MarshalJSONPB(&jsonpb.Marshaler{
+				Indent:       "  ",
+				EmitDefaults: true,
+			})
 		} else {
 			b, err = dmsg.MarshalJSON()
 		}


### PR DESCRIPTION
I assume an output has `a_bool` field.

previously, Evans doesn't emit default values like:
``` bash
{

}
```

I modified that behavior to emit default values like:
``` bash
{
    "a_bool": false
}
```