### PR TITLE
fix help output

### DIFF
--- a/adapter/controller/cli.go
+++ b/adapter/controller/cli.go
@@ -112,8 +112,8 @@ func (c *CLI) parseFlags(args []string) *options {
 			header,
 			web,
 			reflection,
-			version,
 			help,
+			version,
 		)
 	}
 


### PR DESCRIPTION
When --help was called, help message has a problem with  `--help` and `--version` reorder