### PR TITLE
Allow protofiles to be specified by fullpath

### DIFF
--- a/adapter/internal/protoparser/parser.go
+++ b/adapter/internal/protoparser/parser.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ParseFile(fnames []string, paths []string) ([]*desc.FileDescriptor, error) {
-	paths = append(paths, ".")
+	paths = append(paths, "")
 
 	p := &protoparse.Parser{
 		ImportPaths: paths,

--- a/adapter/internal/protoparser/parser.go
+++ b/adapter/internal/protoparser/parser.go
@@ -6,8 +6,6 @@ import (
 )
 
 func ParseFile(fnames []string, paths []string) ([]*desc.FileDescriptor, error) {
-	paths = append(paths, "")
-
 	p := &protoparse.Parser{
 		ImportPaths: paths,
 	}

--- a/adapter/protobuf/message_test.go
+++ b/adapter/protobuf/message_test.go
@@ -47,7 +47,7 @@ func TestMessage(t *testing.T) {
 	})
 
 	t.Run("importing", func(t *testing.T) {
-		libraryProto := testdata("importing", "library.proto")
+		libraryProto := "library.proto"
 		d, err := protoparser.ParseFile([]string{libraryProto}, []string{"testdata/importing"})
 		require.NoError(t, err)
 

--- a/adapter/protobuf/parser_test.go
+++ b/adapter/protobuf/parser_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParseFile(t *testing.T) {
 	t.Run("importing", func(t *testing.T) {
-		fnames := []string{testdata("importing", "library.proto")}
+		fnames := []string{"library.proto"}
 		pkgs, err := ParseFile(fnames, []string{"testdata/importing"})
 		require.NoError(t, err)
 		assert.Len(t, pkgs, 1)

--- a/adapter/protobuf/protobuf_test.go
+++ b/adapter/protobuf/protobuf_test.go
@@ -43,7 +43,3 @@ func toEntitiesFrom(files []*desc.FileDescriptor) ([]*entity.Package, error) {
 
 	return pkgs, nil
 }
-
-func testdata(s ...string) string {
-	return filepath.Join(append([]string{"testdata"}, s...)...)
-}


### PR DESCRIPTION
Allow protofiles to be specified by fullpath.

When specifying the `full path`, the current way of "resolving" it add a `.` in front of it, so it will become a `relative path`.
For example: 
`evans --host=localhost --port=8080 --repl /tmp/test/proto/time.proto` will become `evans --host=localhost --port=8080 --repl ./tmp/test/proto/time.proto` so the proto file will be searched relative to the current path.

Signed-off-by: Ricardo Seriani <ricardo.seriani@gmail.com>