### PR TITLE
fix: crash when request or input is missing in config file.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,6 +117,19 @@ func SetupConfig(c *Config) {
 	}
 	c.REPL.Server = c.Server
 	c.Env.Server = c.Server
+	if c.Request == nil {
+		c.Request = &Request{
+			Header: []Header{
+				{"grpc-client", "evans"},
+			},
+		}
+	}
+
+	if c.Input == nil {
+		c.Input = &Input{
+			PromptFormat: "{ancestor}{name} ({type}) => ",
+		}
+	}
 }
 
 func Get() *Config {


### PR DESCRIPTION
Always set defaults to Request and Input in Config after loading.

fix #142 