### PR TITLE
tagging "v" prefixed version when creating a new release

### DIFF
--- a/.circleci/scripts/create-new-release.bash
+++ b/.circleci/scripts/create-new-release.bash
@@ -8,6 +8,8 @@ fi
 VERSION=$1
 
 git tag "$VERSION"
+git tag "v$VERSION" "$VERSION" # tagging another one which has "v" prefix for Go modules.
 git push origin "$VERSION"
+git push origin "v$VERSION"
 
 ghr -parallel=1 "$VERSION" pkg


### PR DESCRIPTION
To let gomod recognize each release, the release script also pushes "v" prefixed version.