### PR TITLE
add --servername option

### DIFF
--- a/adapter/app/app.go
+++ b/adapter/app/app.go
@@ -66,6 +66,7 @@ func (c *Command) parseFlags(args []string) *options {
 	f.StringVar(&opts.cacert, "cacert", "", "the CA certificate file for verifying the server")
 	f.StringVar(&opts.cert, "cert", "", "the certificate file for mutual TLS auth. it must be provided with --certkey.")
 	f.StringVar(&opts.certKey, "certkey", "", "the private key file for mutual TLS auth. it must be provided with --cert.")
+	f.StringVar(&opts.serverName, "servername", "", "override the server name used to verify the hostname (ignored if --tls is disabled)")
 	f.BoolVarP(&opts.insecure, "insecure", "k", true, "use an insecure connection (ignored if --tls is enabled)")
 	f.BoolVarP(&opts.version, "version", "v", false, "display version and exit")
 	f.BoolVarP(&opts.help, "help", "h", false, "display help text and exit")
@@ -127,6 +128,7 @@ type options struct {
 	cacert     string
 	cert       string
 	certKey    string
+	serverName string
 	insecure   bool
 
 	// meta options

--- a/adapter/grpc/grpc_test.go
+++ b/adapter/grpc/grpc_test.go
@@ -46,7 +46,7 @@ func TestNewClient(t *testing.T) {
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
-			_, err := NewClient(c.addr, c.useReflection, c.useTLS, c.cacert, c.cert, c.certKey)
+			_, err := NewClient(c.addr, "", c.useReflection, c.useTLS, c.cacert, c.cert, c.certKey)
 			if c.err != nil {
 				require.Error(t, err, "NewClient must return an error")
 				assert.Equal(t, c.err, err)

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Server struct {
 	Port       string `toml:"port"`
 	Reflection bool   `toml:"reflection"`
 	TLS        bool   `toml:"tls"`
+	Name       string `toml:"name"`
 }
 
 type Header map[string][]string
@@ -120,6 +121,7 @@ func newDefaultViper() *viper.Viper {
 	v.SetDefault("server.port", "50051")
 	v.SetDefault("server.reflection", false)
 	v.SetDefault("server.tls", false)
+	v.SetDefault("server.name", "")
 
 	v.SetDefault("log.prefix", "evans: ")
 
@@ -143,6 +145,7 @@ func bindFlags(vp *viper.Viper, fs *pflag.FlagSet) {
 		"server.port":         "port",
 		"server.reflection":   "reflection",
 		"server.tls":          "tls",
+		"server.name":         "servername",
 		"request.header":      "header",
 		"request.web":         "web",
 		"request.cacertFile":  "cacert",

--- a/config/testdata/fixtures/create_a_default_global_config_if_both_of_global_and_local_config_are_not_found.golden.toml
+++ b/config/testdata/fixtures/create_a_default_global_config_if_both_of_global_and_local_config_are_not_found.golden.toml
@@ -10,7 +10,7 @@
 
 [meta]
   autoupdate = false
-  configversion = "0.7.2"
+  configversion = "0.7.3"
   updatelevel = "patch"
 
 [repl]
@@ -32,6 +32,7 @@
 
 [server]
   host = "127.0.0.1"
+  name = ""
   port = "50051"
   reflection = false
   tls = false

--- a/config/testdata/fixtures/load_a_global_config_if_local_config_is_not_found.golden.toml
+++ b/config/testdata/fixtures/load_a_global_config_if_local_config_is_not_found.golden.toml
@@ -32,6 +32,7 @@
 
 [server]
   host = "localhost"
+  name = ""
   port = "3000"
   reflection = false
   tls = false

--- a/config/testdata/fixtures/load_a_local_config.golden.toml
+++ b/config/testdata/fixtures/load_a_local_config.golden.toml
@@ -33,6 +33,7 @@
 
 [server]
   host = "localhost"
+  name = ""
   port = "3333"
   reflection = false
   tls = false

--- a/config/testdata/fixtures/will_be_apply_flags.golden.toml
+++ b/config/testdata/fixtures/will_be_apply_flags.golden.toml
@@ -34,6 +34,7 @@
 
 [server]
   host = "localhost"
+  name = ""
   port = "8080"
   reflection = false
   tls = false

--- a/config/testdata/fixtures/will_be_apply_flags_but_local_config_doesnt_exist.golden.toml
+++ b/config/testdata/fixtures/will_be_apply_flags_but_local_config_doesnt_exist.golden.toml
@@ -32,6 +32,7 @@
 
 [server]
   host = "localhost"
+  name = ""
   port = "8080"
   reflection = false
   tls = false

--- a/di/dependency.go
+++ b/di/dependency.go
@@ -234,6 +234,7 @@ func initGRPCClient(cfg *config.Config) error {
 		} else {
 			gRPCClient, err = grpc.NewClient(
 				addr,
+				cfg.Server.Name,
 				cfg.Server.Reflection,
 				cfg.Server.TLS,
 				cfg.Request.CACertFile,

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -5,5 +5,5 @@ import version "github.com/hashicorp/go-version"
 const AppName = "evans"
 
 var (
-	Version = version.Must(version.NewSemver("0.7.2"))
+	Version = version.Must(version.NewSemver("0.7.3"))
 )

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -62,6 +62,7 @@ func TestCLI(t *testing.T) {
 			{args: "--web --reflection --service Greeter --call SayHello", useReflection: true, useWeb: true},
 
 			{args: "--tls -r --host localhost --service Greeter --call SayHello", useReflection: true, useTLS: true, specifyCA: true},
+			{args: "--tls -r --servername localhost --service Greeter --call SayHello", useReflection: true, useTLS: true, specifyCA: true},
 			{args: "--tls --cert testdata/cert/localhost.pem --certkey testdata/cert/localhost-key.pem -r --host localhost --service Greeter --call SayHello", useReflection: true, useTLS: true, specifyCA: true},
 			// If both of --tls and --insecure are provided, --insecure is ignored.
 			{args: "--tls --insecure -r --host localhost --service Greeter --call SayHello", useReflection: true, useTLS: true, specifyCA: true},


### PR DESCRIPTION
When the common name which is for verifying the certificates returned from the server and a gRPC server FQDN are mismatched, we want to a way to override the server name by a specified value.

Implemented #170.