### PR TITLE
add some flags for static linking

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,10 @@ builds:
     - amd64
     - arm
     - '386'
+  flags:
+    - -tags netgo
   ldflags:
-    - '-X github.com/ktr0731/evans/vendor/github.com/ktr0731/go-updater/github.isGitHubReleasedBinary=true'
+    - '-extldflags "-static" -X github.com/ktr0731/evans/vendor/github.com/ktr0731/go-updater/github.isGitHubReleasedBinary=true'
 archives:
 - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 checksum:


### PR DESCRIPTION
In the case of some distributions, Evans will be dynamically linked (ref. #177).
To prevent dynamic linking, I added some flags.