### PR TITLE
wake up channels before creating a new connection

### DIFF
--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -227,11 +227,11 @@ func (c *client) NewClientStream(ctx context.Context, streamDesc *gogrpc.StreamD
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert fqrn to endpoint")
 	}
+	wakeUpClientConn(c.conn)
 	cs, err := c.conn.NewStream(ctx, streamDesc, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate gRPC stream")
 	}
-	wakeUpClientConn(c.conn)
 	return &clientStream{cs}, nil
 }
 


### PR DESCRIPTION
This PR fixes #200.
Currently, Evans checks whether the channel state is READY or not and re-connect if the state is not it.
But, in the case of streaming RPCs, the feature didn't work. This PR fixes it.