### PR TITLE
update protoreflect to the latest commit hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/jhump/protoreflect v1.5.0
+	github.com/jhump/protoreflect v1.5.1-0.20191024213132-10815c273d3f
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/ktr0731/go-multierror v0.0.0-20171204182908-b7773ae21874

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h
 github.com/jhump/protoreflect v0.0.0-20180803214909-95c5cbbeaee7/go.mod h1:eki7DI0mJrpRlDikO63gRZIG0keYYxgKDUdI2QmkZCQ=
 github.com/jhump/protoreflect v1.5.0 h1:NgpVT+dX71c8hZnxHof2M7QDK7QtohIJ7DYycjnkyfc=
 github.com/jhump/protoreflect v1.5.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/jhump/protoreflect v1.5.1-0.20191024213132-10815c273d3f h1:/3LGRkPUNMBo1CxyZ9+AkXGXvPagj2QS/owPN0VlagA=
+github.com/jhump/protoreflect v1.5.1-0.20191024213132-10815c273d3f/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=


### PR DESCRIPTION
The latest `jhump/protoreflect` resolves #197. 