### PR TITLE
add --proto flag

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"text/tabwriter"
 
 	"github.com/ktr0731/evans/cache"
 	"github.com/ktr0731/evans/config"
 	"github.com/ktr0731/evans/cui"
+	"github.com/ktr0731/evans/logger"
 	"github.com/ktr0731/evans/meta"
 	"github.com/ktr0731/evans/mode"
 	"github.com/ktr0731/evans/prompt"
@@ -42,6 +44,10 @@ func runFunc(
 	return func(cmd *cobra.Command, args []string) error {
 		if err := flags.validate(); err != nil {
 			return errors.Wrap(err, "invalid flag condition")
+		}
+
+		if flags.meta.verbose {
+			logger.SetOutput(os.Stderr)
 		}
 
 		switch {

--- a/app/commands.go
+++ b/app/commands.go
@@ -177,6 +177,7 @@ func bindFlags(f *pflag.FlagSet, flags *flags, w io.Writer) {
 	f.StringVar(&flags.common.pkg, "package", "", "default package")
 	f.StringVar(&flags.common.service, "service", "", "default service")
 	f.StringSliceVar(&flags.common.path, "path", nil, "proto file paths")
+	f.StringSliceVar(&flags.common.proto, "proto", nil, "proto file names")
 	f.StringVar(&flags.common.host, "host", "", "gRPC server host")
 	f.StringVarP(&flags.common.port, "port", "p", "50051", "gRPC server port")
 	f.Var(

--- a/app/flag.go
+++ b/app/flag.go
@@ -40,6 +40,7 @@ type flags struct {
 		pkg        string
 		service    string
 		path       []string
+		proto      []string
 		host       string
 		port       string
 		header     map[string][]string

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ func bindFlags(vp *viper.Viper, fs *pflag.FlagSet) {
 	// kv defines the mapping from a viper config name to a flag name.
 	kv := map[string]string{
 		"default.protoPath":   "path",
+		"default.protoFile":   "proto",
 		"default.package":     "package",
 		"default.service":     "service",
 		"server.host":         "host",

--- a/config/testdata/fixtures/apply_some_proto_files_and_paths.golden.toml
+++ b/config/testdata/fixtures/apply_some_proto_files_and_paths.golden.toml
@@ -1,7 +1,7 @@
 
 [default]
   package = ""
-  protofile = []
+  protofile = ["hoge","fuga"]
   protopath = ["foo","bar"]
   service = ""
 

--- a/e2e/old_cli_test.go
+++ b/e2e/old_cli_test.go
@@ -363,6 +363,7 @@ Options:
         --package string                 default package
         --service string                 default service
         --path strings                   proto file paths (default "[]")
+        --proto strings                  proto file names (default "[]")
         --host string                    gRPC server host
         --port, -p string                gRPC server port (default "50051")
         --header slice of strings        default headers that set to each requests (example: foo=bar) (default "[]")


### PR DESCRIPTION
In new interface and v1.0.0, proto files will be specified as `--proto` flags, not arguments. Because specifying proto files are optional.