### PR TITLE
move --package and --service flags into repl command

### DIFF
--- a/app/cli_commands.go
+++ b/app/cli_commands.go
@@ -37,9 +37,9 @@ func newCLICallCommand(flags *flags, ui cui.UI) *cobra.Command {
 		SilenceUsage:  true,
 	}
 
-	bindCLICallFlags(cmd.Flags(), flags, ui.Writer())
+	initFlagSet(cmd.Flags(), ui.Writer())
 
-	cmd.SetHelpFunc(usageFunc(ui.Writer()))
+	cmd.SetHelpFunc(usageFunc(ui.Writer(), []string{"file"}))
 	return cmd
 }
 
@@ -79,6 +79,6 @@ list lists method names belong to the service. If not, list lists all services.`
 	initFlagSet(f, ui.Writer())
 	f.StringVarP(&out, "output", "o", "name", `output format. one of "json" or "name".`)
 
-	cmd.SetHelpFunc(usageFunc(ui.Writer()))
+	cmd.SetHelpFunc(usageFunc(ui.Writer(), nil))
 	return cmd
 }

--- a/app/cli_commands.go
+++ b/app/cli_commands.go
@@ -15,6 +15,10 @@ func newCLICallCommand(flags *flags, ui cui.UI) *cobra.Command {
 		Aliases: []string{"c"},
 		Short:   "call a RPC",
 		Long:    `call invokes a RPC based on the passed method name.`,
+		Example: strings.Join([]string{
+			"        $ echo '{}' | evans -r cli call api.Service.Unary # call Unary method with an empty message",
+			"        $ evans -r cli call -f in.json api.Service.Unary  # call Unary method with an input file",
+		}, "\n"),
 		RunE: runFunc(flags, func(cmd *cobra.Command, cfg *mergedConfig) error {
 			args := cmd.Flags().Args()
 			if len(args) == 0 {

--- a/e2e/old_cli_test.go
+++ b/e2e/old_cli_test.go
@@ -360,8 +360,6 @@ Usage: evans [global options ...] <command>
 
 Options:
         --silent, -s                     hide redundant output (default "false")
-        --package string                 default package
-        --service string                 default service
         --path strings                   comma-separated proto file paths (default "[]")
         --proto strings                  comma-separated proto file names (default "[]")
         --host string                    gRPC server host

--- a/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
@@ -4,6 +4,11 @@ Usage: evans [global options ...] cli call [options ...] <method>
 
 call invokes a RPC based on the passed method name.
 
+Examples:
+        $ echo '{}' | evans -r cli call api.Service.Unary # call Unary method with an empty message
+        $ evans -r cli call -f in.json api.Service.Unary  # call Unary method with an input file
+
 Options:
-        --help, -h        display help text and exit (default "false")
+        --file, -f string        a script file that will be executed by (used only CLI mode)
+        --help, -h               display help text and exit (default "false")
 


### PR DESCRIPTION
`--package` and `--service` flags are required for only `repl` command.