### PR TITLE
implement desc cli command

### DIFF
--- a/app/cli_commands.go
+++ b/app/cli_commands.go
@@ -13,8 +13,8 @@ func newCLICallCommand(flags *flags, ui cui.UI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "call [options ...] <method>",
 		Aliases: []string{"c"},
-		Short:   "call a RPC",
-		Long:    `call invokes a RPC based on the passed method name.`,
+		Short:   "call a method",
+		Long:    `call invokes a method based on the passed method name.`,
 		Example: strings.Join([]string{
 			"        $ echo '{}' | evans -r cli call api.Service.Unary # call Unary method with an empty message",
 			"        $ evans -r cli call -f in.json api.Service.Unary  # call Unary method with an input file",

--- a/app/cli_commands.go
+++ b/app/cli_commands.go
@@ -82,3 +82,38 @@ list lists method names belong to the service. If not, list lists all services.`
 	cmd.SetHelpFunc(usageFunc(ui.Writer(), nil))
 	return cmd
 }
+
+func newCLIDescribeCommand(flags *flags, ui cui.UI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "desc [options ...] [symbol]",
+		Aliases: []string{"describe"},
+		Short:   "describe the descriptor of a symbol",
+		Long: `desc shows the descriptor of the given symbol.
+The symbol should be a fully-qualified name. If no symbol is passed, desc shows all descriptors of the loaded services.`,
+		Example: strings.Join([]string{
+			"        $ evans -r cli desc             # describe the descriptors of the loaded services",
+			`        $ evans -r cli desc api.Service # describe the service descriptor of "api.Service"`,
+			`        $ evans -r cli desc api.Request # describe the message descriptor of "api.Request"`,
+		}, "\n"),
+		RunE: runFunc(flags, func(cmd *cobra.Command, cfg *mergedConfig) error {
+			var fqn string
+			args := cmd.Flags().Args()
+			if len(args) > 0 {
+				fqn = args[0]
+			}
+			invoker := mode.NewDescribeCLIInvoker(ui, fqn)
+			if err := mode.RunAsCLIMode(cfg.Config, invoker); err != nil {
+				return errors.Wrap(err, "failed to run CLI mode")
+			}
+			return nil
+		}),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	f := cmd.Flags()
+	initFlagSet(f, ui.Writer())
+
+	cmd.SetHelpFunc(usageFunc(ui.Writer(), nil))
+	return cmd
+}

--- a/app/commands.go
+++ b/app/commands.go
@@ -215,6 +215,7 @@ func newCLICommand(flags *flags, ui cui.UI) *cobra.Command {
 	cmd.AddCommand(
 		newCLICallCommand(flags, ui),
 		newCLIListCommand(flags, ui),
+		newCLIDescribeCommand(flags, ui),
 	)
 	return cmd
 }

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -481,6 +481,39 @@ func TestE2E_CLI(t *testing.T) {
 			args:         "api.Foo",
 			expectedCode: 1,
 		},
+
+		// desc command
+
+		"describe all service descriptors": {
+			commonFlags:      "--proto testdata/test.proto,testdata/empty_package.proto",
+			cmd:              "desc",
+			args:             "",
+			assertWithGolden: true,
+		},
+		"describe a service descriptor": {
+			commonFlags:      "--proto testdata/test.proto,testdata/empty_package.proto",
+			cmd:              "desc",
+			args:             "api.Example",
+			assertWithGolden: true,
+		},
+		"describe a method descriptor": {
+			commonFlags:      "--proto testdata/test.proto,testdata/empty_package.proto",
+			cmd:              "desc",
+			args:             "api.Example.Unary",
+			assertWithGolden: true,
+		},
+		"describe a message descriptor": {
+			commonFlags:      "--proto testdata/test.proto,testdata/empty_package.proto",
+			cmd:              "desc",
+			args:             "api.SimpleRequest",
+			assertWithGolden: true,
+		},
+		"invalid symbol": {
+			commonFlags:  "--proto testdata/test.proto,testdata/empty_package.proto",
+			cmd:          "desc",
+			args:         "api.Foo",
+			expectedCode: 1,
+		},
 	}
 	for name, c := range cases {
 		c := c

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -484,6 +484,12 @@ func TestE2E_CLI(t *testing.T) {
 
 		// desc command
 
+		"print desc command usage": {
+			commonFlags:      "",
+			cmd:              "desc",
+			args:             "-h",
+			assertWithGolden: true,
+		},
 		"describe all service descriptors": {
 			commonFlags:      "--proto testdata/test.proto,testdata/empty_package.proto",
 			cmd:              "desc",

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_message_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_message_descriptor.golden
@@ -1,0 +1,5 @@
+api.SimpleRequest:
+message SimpleRequest {
+  string name = 1;
+}
+

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_message_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_message_descriptor.golden
@@ -2,4 +2,3 @@ api.SimpleRequest:
 message SimpleRequest {
   string name = 1;
 }
-

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_method_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_method_descriptor.golden
@@ -1,3 +1,2 @@
 api.Example.Unary:
 rpc Unary ( .api.SimpleRequest ) returns ( .api.SimpleResponse );
-

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_method_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_method_descriptor.golden
@@ -1,0 +1,3 @@
+api.Example.Unary:
+rpc Unary ( .api.SimpleRequest ) returns ( .api.SimpleResponse );
+

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_service_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_service_descriptor.golden
@@ -1,0 +1,19 @@
+api.Example:
+service Example {
+  rpc BidiStreaming ( stream .api.SimpleRequest ) returns ( stream .api.SimpleResponse );
+  rpc ClientStreaming ( stream .api.SimpleRequest ) returns ( .api.SimpleResponse );
+  rpc ServerStreaming ( .api.SimpleRequest ) returns ( stream .api.SimpleResponse );
+  rpc Unary ( .api.SimpleRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryBytes ( .api.UnaryBytesRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryEnum ( .api.UnaryEnumRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryHeader ( .api.UnaryHeaderRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMap ( .api.UnaryMapRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMapMessage ( .api.UnaryMapMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMessage ( .api.UnaryMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryOneof ( .api.UnaryOneofRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeated ( .api.UnaryRepeatedRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeatedEnum ( .api.UnaryRepeatedEnumRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeatedMessage ( .api.UnaryRepeatedMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnarySelf ( .api.UnarySelfRequest ) returns ( .api.SimpleResponse );
+}
+

--- a/e2e/testdata/fixtures/teste2e_cli-describe_a_service_descriptor.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_a_service_descriptor.golden
@@ -16,4 +16,3 @@ service Example {
   rpc UnaryRepeatedMessage ( .api.UnaryRepeatedMessageRequest ) returns ( .api.SimpleResponse );
   rpc UnarySelf ( .api.UnarySelfRequest ) returns ( .api.SimpleResponse );
 }
-

--- a/e2e/testdata/fixtures/teste2e_cli-describe_all_service_descriptors.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_all_service_descriptors.golden
@@ -21,4 +21,3 @@ EmptyPackageService:
 service EmptyPackageService {
   rpc Unary ( .SimpleRequest ) returns ( .SimpleResponse );
 }
-

--- a/e2e/testdata/fixtures/teste2e_cli-describe_all_service_descriptors.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-describe_all_service_descriptors.golden
@@ -1,0 +1,24 @@
+api.Example:
+service Example {
+  rpc BidiStreaming ( stream .api.SimpleRequest ) returns ( stream .api.SimpleResponse );
+  rpc ClientStreaming ( stream .api.SimpleRequest ) returns ( .api.SimpleResponse );
+  rpc ServerStreaming ( .api.SimpleRequest ) returns ( stream .api.SimpleResponse );
+  rpc Unary ( .api.SimpleRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryBytes ( .api.UnaryBytesRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryEnum ( .api.UnaryEnumRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryHeader ( .api.UnaryHeaderRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMap ( .api.UnaryMapRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMapMessage ( .api.UnaryMapMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryMessage ( .api.UnaryMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryOneof ( .api.UnaryOneofRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeated ( .api.UnaryRepeatedRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeatedEnum ( .api.UnaryRepeatedEnumRequest ) returns ( .api.SimpleResponse );
+  rpc UnaryRepeatedMessage ( .api.UnaryRepeatedMessageRequest ) returns ( .api.SimpleResponse );
+  rpc UnarySelf ( .api.UnarySelfRequest ) returns ( .api.SimpleResponse );
+}
+
+EmptyPackageService:
+service EmptyPackageService {
+  rpc Unary ( .SimpleRequest ) returns ( .SimpleResponse );
+}
+

--- a/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
@@ -2,7 +2,7 @@ evans 0.8.5
 
 Usage: evans [global options ...] cli call [options ...] <method>
 
-call invokes a RPC based on the passed method name.
+call invokes a method based on the passed method name.
 
 Examples:
         $ echo '{}' | evans -r cli call api.Service.Unary # call Unary method with an empty message

--- a/e2e/testdata/fixtures/teste2e_cli-print_desc_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_desc_command_usage.golden
@@ -1,0 +1,15 @@
+evans 0.8.5
+
+Usage: evans [global options ...] cli desc [options ...] [symbol]
+
+desc shows the descriptor of the given symbol.
+The symbol should be a fully-qualified name. If no symbol is passed, desc shows all descriptors of the loaded services.
+
+Examples:
+        $ evans -r cli desc             # describe the descriptors of the loaded services
+        $ evans -r cli desc api.Service # describe the service descriptor of "api.Service"
+        $ evans -r cli desc api.Request # describe the message descriptor of "api.Request"
+
+Options:
+        --help, -h        display help text and exit (default "false")
+

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
@@ -6,7 +6,7 @@ Options:
         --help, -h        display help text and exit (default "false")
 
 Available Commands:
-        call, c               call a RPC
+        call, c               call a method
         desc, describe        describe the descriptor of a symbol
         list, ls, show        list services or methods
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
@@ -7,5 +7,6 @@ Options:
 
 Available Commands:
         call, c               call a RPC
+        desc, describe        describe the descriptor of a symbol
         list, ls, show        list services or methods
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
@@ -6,7 +6,7 @@ Options:
         --help, -h        display help text and exit (default "false")
 
 Available Commands:
-        call, c               call a RPC
+        call, c               call a method
         desc, describe        describe the descriptor of a symbol
         list, ls, show        list services or methods
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
@@ -7,5 +7,6 @@ Options:
 
 Available Commands:
         call, c               call a RPC
+        desc, describe        describe the descriptor of a symbol
         list, ls, show        list services or methods
 

--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,14 @@ go 1.12
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.3.3
 	github.com/google/go-cmp v0.4.0
-	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/improbable-eng/grpc-web v0.12.0 // indirect
 	github.com/jhump/protoreflect v1.5.1-0.20191024213132-10815c273d3f
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
-	github.com/ktr0731/dept v0.1.3 // indirect
 	github.com/ktr0731/go-multierror v0.0.0-20171204182908-b7773ae21874
 	github.com/ktr0731/go-prompt v0.2.2-0.20190609072126-7894cc3f2925
 	github.com/ktr0731/go-shellstring v0.1.1
@@ -35,7 +31,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	github.com/rakyll/statik v0.1.6
-	github.com/rs/cors v1.7.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -45,11 +40,8 @@ require (
 	github.com/tj/go-spin v1.1.0
 	github.com/zchee/go-xdgbasedir v1.0.3
 	go.uber.org/goleak v0.10.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0
-	google.golang.org/genproto v0.0.0-20200204235621-fb4a7afc5178 // indirect
 	google.golang.org/grpc v1.27.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -134,8 +135,6 @@ github.com/ktr0731/go-shellstring v0.1.1/go.mod h1:f0/XX0hsm6A02Es/UDQ9MGd3VqpCH
 github.com/ktr0731/go-updater v0.1.5 h1:AiaQxJoI0OTGqvsJYdIITCOaEzQQOqU2MHKUwttVShY=
 github.com/ktr0731/go-updater v0.1.5/go.mod h1:dsdOg7a9sj6ttcOU5ZxPCtKdm9WeB1hwcX/7oKgz9/0=
 github.com/ktr0731/grpc-test v0.1.0/go.mod h1:deptvEeND4faWsF2MGTanL6/2SaX8lgdmF3yEXWge5U=
-github.com/ktr0731/grpc-test v0.1.3 h1:88d03K6UFQr1LgPXDrq2pHyZfm701Wk7Ihu7qIswPZc=
-github.com/ktr0731/grpc-test v0.1.3/go.mod h1:oc15uRUOCpCgG+k9Opa+repI3elFAP8XizC4FWNQ2+Q=
 github.com/ktr0731/grpc-test v0.1.4 h1:FtZtbAUcQY1nye7zwwjZBT8usJkusWF0+Gtq+UlHyGU=
 github.com/ktr0731/grpc-test v0.1.4/go.mod h1:v47616grayBYXQveGWxO3OwjLB3nEEnHsZuMTc73FM0=
 github.com/ktr0731/grpc-web-go-client v0.2.5-0.20190505140201-c24452752d52 h1:4q+JNdJMjzBqUEjcq/z3Lnqr0W3UkF7+sATxzDK/mJ8=
@@ -196,7 +195,6 @@ github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
@@ -293,7 +291,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -316,7 +313,6 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
@@ -345,15 +341,12 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1 h1:aQktFqmDE2yjveXJlVIfslDFmFnUXSqG0i6KRcJAeMc=
-google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200204235621-fb4a7afc5178 h1:4mrurAiSXsNNb6GoJatrIsnI+JqKHAVQQ1SbMS5OtDI=
 google.golang.org/genproto v0.0.0-20200204235621-fb4a7afc5178/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/idl/idl.go
+++ b/idl/idl.go
@@ -22,7 +22,7 @@ var (
 	ErrUnknownPackageName = errors.New("unknown package name")
 	ErrUnknownServiceName = errors.New("unknown service name")
 	ErrUnknownRPCName     = errors.New("unknown RPC name")
-	ErrUnknownMessageName = errors.New("unknown message name")
+	ErrUnknownSymbol      = errors.New("unknown symbol")
 )
 
 // Spec represents the interface specification from loaded IDL files.
@@ -49,14 +49,17 @@ type Spec interface {
 	//
 	RPC(svcName, rpcName string) (*grpc.RPC, error)
 
-	// TypeDescriptor returns the descriptor of a type specified by msgName.
-	// Message name should be fully-qualified (the form of <package>.<message> in Protocol Buffers3).
+	// ResolveSymbol returns the descriptor of a symbol.
+	// The symbol should be fully-qualified (the form of <package>.<message> in Protocol Buffers3).
 	// The returned descriptor depends to an codec such that Protocol Buffers.
-	// TypeDescriptor may returns these errors:
+	// ResolveSymbol may returns these errors:
 	//
-	//   - ErrUnknownMessage: msgName is not loaded.
+	//   - ErrUnknownSymbol: symbol is not loaded.
 	//
-	TypeDescriptor(msgName string) (interface{}, error)
+	ResolveSymbol(symbol string) (interface{}, error)
+
+	// FormatDescriptor formats v according to its IDL type.
+	FormatDescriptor(v interface{}) (string, error)
 }
 
 // FullyQualifiedMethodName returns the fully-qualified method joined with '.'.

--- a/idl/idl_test.go
+++ b/idl/idl_test.go
@@ -1,6 +1,7 @@
 package idl_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -97,14 +98,14 @@ func TestSpec(t *testing.T) {
 					}
 				})
 
-				t.Run("TypeDescriptor", func(t *testing.T) {
-					_, err := spec.TypeDescriptor("Foo")
-					if err == nil {
-						t.Fatalf("TypeDescriptor must return an error because api.Foo is an undefined type, but got nil")
+				t.Run("ResolveSymbol", func(t *testing.T) {
+					_, err := spec.ResolveSymbol("Foo")
+					if !errors.Is(err, idl.ErrUnknownSymbol) {
+						t.Fatalf("ResolveSymbol must return ErrUnknownSymbol because api.Foo is an undefined type, but got '%s'", err)
 					}
-					actual, err := spec.TypeDescriptor("api.Request")
+					actual, err := spec.ResolveSymbol("api.Request")
 					if err != nil {
-						t.Fatalf("TypeDescriptor must return the descriptor of api.Request, but got an error: '%s'", err)
+						t.Fatalf("ResolveSymbol must return the descriptor of api.Request, but got an error: '%s'", err)
 					}
 
 					if actual == nil {
@@ -165,10 +166,10 @@ func TestSpec(t *testing.T) {
 					}
 				})
 
-				t.Run("TypeDescriptor", func(t *testing.T) {
-					actual, err := spec.TypeDescriptor("Request")
+				t.Run("ResolveSymbol", func(t *testing.T) {
+					actual, err := spec.ResolveSymbol("Request")
 					if err != nil {
-						t.Fatalf("TypeDescriptor must return the descriptor of api.Request, but got an error: '%s'", err)
+						t.Fatalf("ResolveSymbol must return the descriptor of api.Request, but got an error: '%s'", err)
 					}
 
 					if actual == nil {

--- a/idl/proto/proto.go
+++ b/idl/proto/proto.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/jhump/protoreflect/desc/protoprint"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/ktr0731/evans/grpc"
 	"github.com/ktr0731/evans/grpc/grpcreflection"
@@ -16,7 +17,8 @@ import (
 )
 
 type spec struct {
-	pkgNames []string
+	fileDescs []*desc.FileDescriptor
+	pkgNames  []string
 	// Loaded service descriptors.
 	svcDescs []*desc.ServiceDescriptor
 	// key: fully qualified service name, val: method descriptors belong to the service.
@@ -93,13 +95,35 @@ func (s *spec) RPC(svcName, rpcName string) (*grpc.RPC, error) {
 	return nil, idl.ErrUnknownRPCName
 }
 
-// TypeDescriptor returns the descriptor of a message.
+// ResolveSymbol returns the descriptor of the passed fully-qualified descriptor name.
 // The actual type of the returned interface{} is *desc.MessageDescriptor.
-func (s *spec) TypeDescriptor(msgName string) (interface{}, error) {
-	if m, ok := s.msgDescs[msgName]; ok {
-		return m, nil
+func (s *spec) ResolveSymbol(symbol string) (interface{}, error) {
+	for _, f := range s.fileDescs {
+		d := f.FindSymbol(symbol)
+		if d != nil {
+			return d, nil
+		}
 	}
-	return nil, idl.ErrUnknownMessageName
+	return nil, idl.ErrUnknownSymbol
+}
+
+// FormatDescriptor formats v as a Protocol Buffers descriptor type.
+// If v doesn't implement desc.Descriptor, it returns an error.
+func (s *spec) FormatDescriptor(v interface{}) (string, error) {
+	desc, ok := v.(desc.Descriptor)
+	if !ok {
+		return "", errors.New("v should be a desc.Descriptor")
+	}
+	p := &protoprint.Printer{
+		Compact:                  true,
+		ForceFullyQualifiedNames: true,
+		SortElements:             true,
+	}
+	str, err := p.PrintProtoToString(desc)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to convert the descriptor to string")
+	}
+	return str, nil
 }
 
 // LoadFiles receives proto file names and import paths like protoc's options.
@@ -163,10 +187,11 @@ func newSpec(fds []*desc.FileDescriptor) idl.Spec {
 	})
 
 	return &spec{
-		pkgNames: pkgNames,
-		svcDescs: svcDescs,
-		rpcDescs: rpcDescs,
-		msgDescs: msgDescs,
+		fileDescs: fds,
+		pkgNames:  pkgNames,
+		svcDescs:  svcDescs,
+		rpcDescs:  rpcDescs,
+		msgDescs:  msgDescs,
 	}
 }
 

--- a/idl/proto/proto.go
+++ b/idl/proto/proto.go
@@ -123,7 +123,7 @@ func (s *spec) FormatDescriptor(v interface{}) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert the descriptor to string")
 	}
-	return str, nil
+	return strings.TrimSpace(str), nil
 }
 
 // LoadFiles receives proto file names and import paths like protoc's options.

--- a/idl/proto/proto.go
+++ b/idl/proto/proto.go
@@ -96,7 +96,7 @@ func (s *spec) RPC(svcName, rpcName string) (*grpc.RPC, error) {
 }
 
 // ResolveSymbol returns the descriptor of the passed fully-qualified descriptor name.
-// The actual type of the returned interface{} is *desc.MessageDescriptor.
+// The actual type of the returned interface{} implements desc.Descriptor.
 func (s *spec) ResolveSymbol(symbol string) (interface{}, error) {
 	for _, f := range s.fileDescs {
 		d := f.FindSymbol(symbol)

--- a/mode/cli.go
+++ b/mode/cli.go
@@ -138,6 +138,25 @@ func NewListCLIInvoker(ui cui.UI, fqn, format string) CLIInvoker {
 	}
 }
 
+func NewDescribeCLIInvoker(ui cui.UI, fqn string) CLIInvoker {
+	return func(context.Context) error {
+		var (
+			out string
+			err error
+		)
+		if fqn != "" {
+			out, err = usecase.FormatDescriptor(fqn)
+		} else {
+			out, err = usecase.FormatFileDescriptors()
+		}
+		if err != nil {
+			return errors.Wrap(err, "failed to describe")
+		}
+		ui.Output(out)
+		return nil
+	}
+}
+
 // RunAsCLIMode starts Evans as CLI mode.
 func RunAsCLIMode(cfg *config.Config, invoker CLIInvoker) error {
 	var injectResult error

--- a/mode/cli.go
+++ b/mode/cli.go
@@ -147,7 +147,7 @@ func NewDescribeCLIInvoker(ui cui.UI, fqn string) CLIInvoker {
 		if fqn != "" {
 			out, err = usecase.FormatDescriptor(fqn)
 		} else {
-			out, err = usecase.FormatFileDescriptors()
+			out, err = usecase.FormatServiceDescriptors()
 		}
 		if err != nil {
 			return errors.Wrap(err, "failed to describe")

--- a/repl/mock_test.go
+++ b/repl/mock_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	lockSpecMockPackageNames   sync.RWMutex
-	lockSpecMockRPC            sync.RWMutex
-	lockSpecMockRPCs           sync.RWMutex
-	lockSpecMockServiceNames   sync.RWMutex
-	lockSpecMockTypeDescriptor sync.RWMutex
+	lockSpecMockFormatDescriptor sync.RWMutex
+	lockSpecMockRPC              sync.RWMutex
+	lockSpecMockRPCs             sync.RWMutex
+	lockSpecMockResolveSymbol    sync.RWMutex
+	lockSpecMockServiceNames     sync.RWMutex
 )
 
 // Ensure, that SpecMock does implement idl.Spec.
@@ -27,8 +27,8 @@ var _ idl.Spec = &SpecMock{}
 //
 //         // make and configure a mocked idl.Spec
 //         mockedSpec := &SpecMock{
-//             PackageNamesFunc: func() []string {
-// 	               panic("mock out the PackageNames method")
+//             FormatDescriptorFunc: func(v interface{}) (string, error) {
+// 	               panic("mock out the FormatDescriptor method")
 //             },
 //             RPCFunc: func(svcName string, rpcName string) (*grpc.RPC, error) {
 // 	               panic("mock out the RPC method")
@@ -36,11 +36,11 @@ var _ idl.Spec = &SpecMock{}
 //             RPCsFunc: func(svcName string) ([]*grpc.RPC, error) {
 // 	               panic("mock out the RPCs method")
 //             },
+//             ResolveSymbolFunc: func(symbol string) (interface{}, error) {
+// 	               panic("mock out the ResolveSymbol method")
+//             },
 //             ServiceNamesFunc: func() []string {
 // 	               panic("mock out the ServiceNames method")
-//             },
-//             TypeDescriptorFunc: func(msgName string) (interface{}, error) {
-// 	               panic("mock out the TypeDescriptor method")
 //             },
 //         }
 //
@@ -49,8 +49,8 @@ var _ idl.Spec = &SpecMock{}
 //
 //     }
 type SpecMock struct {
-	// PackageNamesFunc mocks the PackageNames method.
-	PackageNamesFunc func() []string
+	// FormatDescriptorFunc mocks the FormatDescriptor method.
+	FormatDescriptorFunc func(v interface{}) (string, error)
 
 	// RPCFunc mocks the RPC method.
 	RPCFunc func(svcName string, rpcName string) (*grpc.RPC, error)
@@ -58,16 +58,18 @@ type SpecMock struct {
 	// RPCsFunc mocks the RPCs method.
 	RPCsFunc func(svcName string) ([]*grpc.RPC, error)
 
+	// ResolveSymbolFunc mocks the ResolveSymbol method.
+	ResolveSymbolFunc func(symbol string) (interface{}, error)
+
 	// ServiceNamesFunc mocks the ServiceNames method.
 	ServiceNamesFunc func() []string
 
-	// TypeDescriptorFunc mocks the TypeDescriptor method.
-	TypeDescriptorFunc func(msgName string) (interface{}, error)
-
 	// calls tracks calls to the methods.
 	calls struct {
-		// PackageNames holds details about calls to the PackageNames method.
-		PackageNames []struct {
+		// FormatDescriptor holds details about calls to the FormatDescriptor method.
+		FormatDescriptor []struct {
+			// V is the v argument value.
+			V interface{}
 		}
 		// RPC holds details about calls to the RPC method.
 		RPC []struct {
@@ -81,40 +83,45 @@ type SpecMock struct {
 			// SvcName is the svcName argument value.
 			SvcName string
 		}
+		// ResolveSymbol holds details about calls to the ResolveSymbol method.
+		ResolveSymbol []struct {
+			// Symbol is the symbol argument value.
+			Symbol string
+		}
 		// ServiceNames holds details about calls to the ServiceNames method.
 		ServiceNames []struct {
 		}
-		// TypeDescriptor holds details about calls to the TypeDescriptor method.
-		TypeDescriptor []struct {
-			// MsgName is the msgName argument value.
-			MsgName string
-		}
 	}
 }
 
-// PackageNames calls PackageNamesFunc.
-func (mock *SpecMock) PackageNames() []string {
-	if mock.PackageNamesFunc == nil {
-		panic("SpecMock.PackageNamesFunc: method is nil but Spec.PackageNames was just called")
+// FormatDescriptor calls FormatDescriptorFunc.
+func (mock *SpecMock) FormatDescriptor(v interface{}) (string, error) {
+	if mock.FormatDescriptorFunc == nil {
+		panic("SpecMock.FormatDescriptorFunc: method is nil but Spec.FormatDescriptor was just called")
 	}
 	callInfo := struct {
-	}{}
-	lockSpecMockPackageNames.Lock()
-	mock.calls.PackageNames = append(mock.calls.PackageNames, callInfo)
-	lockSpecMockPackageNames.Unlock()
-	return mock.PackageNamesFunc()
+		V interface{}
+	}{
+		V: v,
+	}
+	lockSpecMockFormatDescriptor.Lock()
+	mock.calls.FormatDescriptor = append(mock.calls.FormatDescriptor, callInfo)
+	lockSpecMockFormatDescriptor.Unlock()
+	return mock.FormatDescriptorFunc(v)
 }
 
-// PackageNamesCalls gets all the calls that were made to PackageNames.
+// FormatDescriptorCalls gets all the calls that were made to FormatDescriptor.
 // Check the length with:
-//     len(mockedSpec.PackageNamesCalls())
-func (mock *SpecMock) PackageNamesCalls() []struct {
+//     len(mockedSpec.FormatDescriptorCalls())
+func (mock *SpecMock) FormatDescriptorCalls() []struct {
+	V interface{}
 } {
 	var calls []struct {
+		V interface{}
 	}
-	lockSpecMockPackageNames.RLock()
-	calls = mock.calls.PackageNames
-	lockSpecMockPackageNames.RUnlock()
+	lockSpecMockFormatDescriptor.RLock()
+	calls = mock.calls.FormatDescriptor
+	lockSpecMockFormatDescriptor.RUnlock()
 	return calls
 }
 
@@ -184,6 +191,37 @@ func (mock *SpecMock) RPCsCalls() []struct {
 	return calls
 }
 
+// ResolveSymbol calls ResolveSymbolFunc.
+func (mock *SpecMock) ResolveSymbol(symbol string) (interface{}, error) {
+	if mock.ResolveSymbolFunc == nil {
+		panic("SpecMock.ResolveSymbolFunc: method is nil but Spec.ResolveSymbol was just called")
+	}
+	callInfo := struct {
+		Symbol string
+	}{
+		Symbol: symbol,
+	}
+	lockSpecMockResolveSymbol.Lock()
+	mock.calls.ResolveSymbol = append(mock.calls.ResolveSymbol, callInfo)
+	lockSpecMockResolveSymbol.Unlock()
+	return mock.ResolveSymbolFunc(symbol)
+}
+
+// ResolveSymbolCalls gets all the calls that were made to ResolveSymbol.
+// Check the length with:
+//     len(mockedSpec.ResolveSymbolCalls())
+func (mock *SpecMock) ResolveSymbolCalls() []struct {
+	Symbol string
+} {
+	var calls []struct {
+		Symbol string
+	}
+	lockSpecMockResolveSymbol.RLock()
+	calls = mock.calls.ResolveSymbol
+	lockSpecMockResolveSymbol.RUnlock()
+	return calls
+}
+
 // ServiceNames calls ServiceNamesFunc.
 func (mock *SpecMock) ServiceNames() []string {
 	if mock.ServiceNamesFunc == nil {
@@ -207,36 +245,5 @@ func (mock *SpecMock) ServiceNamesCalls() []struct {
 	lockSpecMockServiceNames.RLock()
 	calls = mock.calls.ServiceNames
 	lockSpecMockServiceNames.RUnlock()
-	return calls
-}
-
-// TypeDescriptor calls TypeDescriptorFunc.
-func (mock *SpecMock) TypeDescriptor(msgName string) (interface{}, error) {
-	if mock.TypeDescriptorFunc == nil {
-		panic("SpecMock.TypeDescriptorFunc: method is nil but Spec.TypeDescriptor was just called")
-	}
-	callInfo := struct {
-		MsgName string
-	}{
-		MsgName: msgName,
-	}
-	lockSpecMockTypeDescriptor.Lock()
-	mock.calls.TypeDescriptor = append(mock.calls.TypeDescriptor, callInfo)
-	lockSpecMockTypeDescriptor.Unlock()
-	return mock.TypeDescriptorFunc(msgName)
-}
-
-// TypeDescriptorCalls gets all the calls that were made to TypeDescriptor.
-// Check the length with:
-//     len(mockedSpec.TypeDescriptorCalls())
-func (mock *SpecMock) TypeDescriptorCalls() []struct {
-	MsgName string
-} {
-	var calls []struct {
-		MsgName string
-	}
-	lockSpecMockTypeDescriptor.RLock()
-	calls = mock.calls.TypeDescriptor
-	lockSpecMockTypeDescriptor.RUnlock()
 	return calls
 }

--- a/usecase/format_descriptor.go
+++ b/usecase/format_descriptor.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// FormatDescriptor formats all package names.
+// FormatDescriptor formats the descriptor of the passed symbol.
 func FormatDescriptor(symbol string) (string, error) {
 	return dm.FormatDescriptor(symbol)
 }

--- a/usecase/format_descriptor.go
+++ b/usecase/format_descriptor.go
@@ -1,0 +1,23 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// FormatDescriptor formats all package names.
+func FormatDescriptor(symbol string) (string, error) {
+	return dm.FormatDescriptor(symbol)
+}
+func (m *dependencyManager) FormatDescriptor(symbol string) (string, error) {
+	v, err := m.spec.ResolveSymbol(symbol)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve symbol '%s'", symbol)
+	}
+	out, err := m.spec.FormatDescriptor(v)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to format the descriptor of symbol '%s'", symbol)
+	}
+	return fmt.Sprintf("%s:\n%s", symbol, out), nil
+}

--- a/usecase/format_service_descriptors.go
+++ b/usecase/format_service_descriptors.go
@@ -1,0 +1,24 @@
+package usecase
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// FormatFileDescriptors formats all file descriptors the spec loaded.
+func FormatFileDescriptors() (string, error) {
+	return dm.FormatFileDescriptors()
+}
+func (m *dependencyManager) FormatFileDescriptors() (string, error) {
+	svcs := ListServices()
+	out := make([]string, 0, len(svcs))
+	for _, s := range svcs {
+		o, err := FormatDescriptor(s)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to format one service descriptor")
+		}
+		out = append(out, o)
+	}
+	return strings.Join(out, "\n"), nil
+}

--- a/usecase/format_service_descriptors.go
+++ b/usecase/format_service_descriptors.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// FormatFileDescriptors formats all file descriptors the spec loaded.
-func FormatFileDescriptors() (string, error) {
-	return dm.FormatFileDescriptors()
+// FormatServiceDescriptors formats all service descriptors the spec loaded.
+func FormatServiceDescriptors() (string, error) {
+	return dm.FormatServiceDescriptors()
 }
-func (m *dependencyManager) FormatFileDescriptors() (string, error) {
+func (m *dependencyManager) FormatServiceDescriptors() (string, error) {
 	svcs := ListServices()
 	out := make([]string, 0, len(svcs))
 	for _, s := range svcs {

--- a/usecase/format_service_descriptors.go
+++ b/usecase/format_service_descriptors.go
@@ -20,5 +20,5 @@ func (m *dependencyManager) FormatFileDescriptors() (string, error) {
 		}
 		out = append(out, o)
 	}
-	return strings.Join(out, "\n"), nil
+	return strings.Join(out, "\n\n"), nil
 }

--- a/usecase/get_type_descriptor.go
+++ b/usecase/get_type_descriptor.go
@@ -15,7 +15,7 @@ func (m *dependencyManager) GetTypeDescriptor(typeName string) (interface{}, err
 		pkgName = "''"
 	}
 	fqmn := proto.FullyQualifiedMessageName(pkgName, typeName)
-	d, err := m.spec.TypeDescriptor(fqmn)
+	d, err := m.spec.ResolveSymbol(fqmn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get the type descriptor of '%s'", typeName)
 	}


### PR DESCRIPTION
This PR is a part of #189 

Evans now supports descriptor inspection from CLI mode.
This feature is highly inspired by `grpc_cli` and `grpcurl`.

See `$ evans cli desc -h` for the usage and more detail.