### PR TITLE
status details support

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -436,6 +436,15 @@ func TestE2E_CLI(t *testing.T) {
 			assertWithGolden: true,
 			expectedCode:     1,
 		},
+		"call failure unary RPC with --enrich and JSON format": {
+			commonFlags:      "-r --service Example",
+			cmd:              "call",
+			args:             "--file testdata/unary_call.in --enrich UnaryHeaderTrailerFailure --output json",
+			reflection:       true,
+			unflatten:        true,
+			assertWithGolden: true,
+			expectedCode:     1,
+		},
 		"call unary RPC with --enrich flag against to gRPC-Web server": {
 			commonFlags:      "--web -r --service Example",
 			cmd:              "call",

--- a/e2e/repl_test.go
+++ b/e2e/repl_test.go
@@ -66,6 +66,11 @@ func TestE2E_REPL(t *testing.T) {
 			commonFlags: "--proto testdata/test.proto",
 			input:       []interface{}{"package api", "service Example", "call --enrich Unary", "kaguya"},
 		},
+		"call UnaryHeaderTrailerFailure by selecting package and service with enriched output": {
+			commonFlags: "--proto testdata/test.proto",
+			input:       []interface{}{"package api", "service Example", "call --enrich UnaryHeaderTrailerFailure", "kaguya"},
+			hasErr:      true,
+		},
 		"call Unary by selecting only service": {
 			commonFlags: "--proto testdata/test.proto",
 			input:       []interface{}{"service Example", "call Unary", "kaguya"},

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_and_json_format.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_and_json_format.golden
@@ -1,0 +1,50 @@
+{
+  "status": {
+    "code": "Internal",
+    "number": 13,
+    "message": "internal error",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.BadRequest",
+        "fieldViolations": [
+          {
+            "description": "description",
+            "field": "field"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.PreconditionFailure",
+        "violations": [
+          {
+            "description": "description",
+            "subject": "subject",
+            "type": "type"
+          }
+        ]
+      }
+    ]
+  },
+  "header": {
+    "content-type": [
+      "application/grpc"
+    ],
+    "header_key1": [
+      "header_val1"
+    ],
+    "header_key2": [
+      "header_val2"
+    ]
+  },
+  "messages": [
+    {}
+  ],
+  "trailer": {
+    "trailer_key1": [
+      "trailer_val1"
+    ],
+    "trailer_key2": [
+      "trailer_val2"
+    ]
+  }
+}

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag.golden
@@ -7,4 +7,6 @@ header_key2: header_val2
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
-code = Internal, number = 13, message = "internal error"
+code: Internal
+number: 13
+message: "internal error"

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
@@ -5,10 +5,12 @@ vary: Origin
 
 {}
 
-grpc-status-details-bin: CA0SDmludGVybmFsIGVycm9yGkMKKXR5cGUuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLnJwYy5CYWRSZXF1ZXN0EhYKFAoFZmllbGQSC2Rlc2NyaXB0aW9uGlQKMnR5cGUuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLnJwYy5QcmVjb25kaXRpb25GYWlsdXJlEh4KHAoEdHlwZRIHc3ViamVjdBoLZGVzY3JpcHRpb24
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
 code: Internal
 number: 13
 message: "internal error"
+details: 
+  {"@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [{"description": "description", "field": "field"}]}
+  {"@type": "type.googleapis.com/google.rpc.PreconditionFailure", "violations": [{"description": "description", "subject": "subject", "type": "type"}]}

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
@@ -8,4 +8,6 @@ vary: Origin
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
-code = Internal, number = 13, message = "internal error"
+code: Internal
+number: 13
+message: "internal error"

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
@@ -5,6 +5,7 @@ vary: Origin
 
 {}
 
+grpc-status-details-bin: CA0SDmludGVybmFsIGVycm9yGkMKKXR5cGUuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLnJwYy5CYWRSZXF1ZXN0EhYKFAoFZmllbGQSC2Rlc2NyaXB0aW9uGlQKMnR5cGUuZ29vZ2xlYXBpcy5jb20vZ29vZ2xlLnJwYy5QcmVjb25kaXRpb25GYWlsdXJlEh4KHAoEdHlwZRIHc3ViamVjdBoLZGVzY3JpcHRpb24
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 

--- a/e2e/testdata/fixtures/teste2e_cli-call_unary_rpc_with_--enrich_flag.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_unary_rpc_with_--enrich_flag.golden
@@ -9,4 +9,6 @@ header_key2: header_val2
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
-code = OK, number = 0, message = ""
+code: OK
+number: 0
+message: ""

--- a/e2e/testdata/fixtures/teste2e_cli-call_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
@@ -10,4 +10,6 @@ vary: Origin
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
-code = OK, number = 0, message = ""
+code: OK
+number: 0
+message: ""

--- a/e2e/testdata/fixtures/teste2e_repl-call_unary_by_selecting_package_and_service_with_enriched_output.golden
+++ b/e2e/testdata/fixtures/teste2e_repl-call_unary_by_selecting_package_and_service_with_enriched_output.golden
@@ -11,5 +11,7 @@ header_key2: header_val2
 trailer_key1: trailer_val1
 trailer_key2: trailer_val2
 
-code = OK, number = 0, message = ""
+code: OK
+number: 0
+message: ""
 

--- a/e2e/testdata/fixtures/teste2e_repl-call_unaryheadertrailerfailure_by_selecting_package_and_service_with_enriched_output.golden
+++ b/e2e/testdata/fixtures/teste2e_repl-call_unaryheadertrailerfailure_by_selecting_package_and_service_with_enriched_output.golden
@@ -1,3 +1,5 @@
+
+
 content-type: application/grpc
 header_key1: header_val1
 header_key2: header_val2
@@ -13,3 +15,4 @@ message: "internal error"
 details: 
   {"@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [{"description": "description", "field": "field"}]}
   {"@type": "type.googleapis.com/google.rpc.PreconditionFailure", "violations": [{"description": "description", "subject": "subject", "type": "type"}]}
+

--- a/format/curl/curl.go
+++ b/format/curl/curl.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck
+	"github.com/golang/protobuf/proto"  //nolint:staticcheck
 	"github.com/golang/protobuf/ptypes"
 	"github.com/ktr0731/evans/format"
 	"github.com/ktr0731/evans/present"

--- a/format/curl/curl.go
+++ b/format/curl/curl.go
@@ -2,11 +2,15 @@
 package curl
 
 import (
+	"bytes"
+	gojson "encoding/json"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 	"github.com/ktr0731/evans/format"
 	"github.com/ktr0731/evans/present"
 	"github.com/ktr0731/evans/present/json"
@@ -14,22 +18,24 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type responsePresenter struct {
+type responseFormatter struct {
 	w io.Writer
 
-	json present.Presenter
+	json        present.Presenter
+	pbMarshaler *jsonpb.Marshaler
 
 	wroteHeader, wroteMessage, wroteTrailer bool
 }
 
 func NewResponseFormatter(w io.Writer) format.ResponseFormatterInterface {
-	return &responsePresenter{
-		w:    w,
-		json: json.NewPresenter("  "),
+	return &responseFormatter{
+		w:           w,
+		json:        json.NewPresenter("  "),
+		pbMarshaler: &jsonpb.Marshaler{},
 	}
 }
 
-func (p *responsePresenter) FormatHeader(header metadata.MD) {
+func (p *responseFormatter) FormatHeader(header metadata.MD) {
 	var s []string
 	for k, v := range header {
 		for _, vv := range v {
@@ -44,7 +50,7 @@ func (p *responsePresenter) FormatHeader(header metadata.MD) {
 	p.wroteHeader = true
 }
 
-func (p *responsePresenter) FormatMessage(v interface{}) error {
+func (p *responseFormatter) FormatMessage(v interface{}) error {
 	if p.wroteHeader {
 		fmt.Fprintf(p.w, "\n")
 	}
@@ -59,7 +65,10 @@ func (p *responsePresenter) FormatMessage(v interface{}) error {
 	return nil
 }
 
-func (p *responsePresenter) FormatTrailer(trailer metadata.MD) {
+func (p *responseFormatter) FormatTrailer(trailer metadata.MD) {
+	if len(trailer) == 0 {
+		return
+	}
 	if p.wroteHeader || p.wroteMessage {
 		fmt.Fprintf(p.w, "\n")
 	}
@@ -78,13 +87,46 @@ func (p *responsePresenter) FormatTrailer(trailer metadata.MD) {
 	p.wroteTrailer = true
 }
 
-func (p *responsePresenter) FormatStatus(status *status.Status) {
+func (p *responseFormatter) FormatStatus(status *status.Status) error {
 	if p.wroteHeader || p.wroteMessage || p.wroteTrailer {
 		fmt.Fprintf(p.w, "\n")
 	}
-	fmt.Fprintf(p.w, "code = %s, number = %d, message = %q\n", status.Code().String(), status.Code(), status.Message())
+	fmt.Fprintf(p.w, "code: %s\nnumber: %d\nmessage: %q\n", status.Code().String(), status.Code(), status.Message())
+	if len(status.Details()) > 0 {
+		details := make([]interface{}, 0, len(status.Details()))
+		for _, d := range status.Details() {
+			d, ok := d.(proto.Message)
+			if !ok {
+				continue
+			}
+			m, err := p.convertProtoMessageToMap(d)
+			if err != nil {
+				return err
+			}
+			details = append(details, m)
+		}
+		b, err := gojson.MarshalIndent(details, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(p.w, "details: \n%s\n", string(b))
+	}
+	return nil
 }
 
-func (p *responsePresenter) Done() error {
+func (p *responseFormatter) Done() error {
 	return nil
+}
+
+func (p *responseFormatter) convertProtoMessageToMap(m proto.Message) (map[string]interface{}, error) {
+	var buf bytes.Buffer
+	err := p.pbMarshaler.Marshal(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+	var res map[string]interface{}
+	if err := gojson.Unmarshal(buf.Bytes(), &res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -22,8 +22,9 @@ func (f *formatter) FormatMessage(v interface{}) error {
 	return nil
 }
 
-func (f *formatter) FormatStatus(status *status.Status) {
+func (f *formatter) FormatStatus(status *status.Status) error {
 	f.FormatStatusCalled = true
+	return nil
 }
 
 func (f *formatter) FormatTrailer(trailer metadata.MD) {
@@ -49,9 +50,11 @@ func TestResponseFormatter(t *testing.T) {
 			f := NewResponseFormatter(impl, c.enrich)
 			f.FormatHeader(metadata.Pairs("key", "val"))
 			if err := f.FormatMessage(struct{}{}); err != nil {
-				t.Fatalf("FormatMessage should no return an error, but got '%s'", err)
+				t.Fatalf("FormatMessage should not return an error, but got '%s'", err)
 			}
-			f.FormatTrailer(status.New(codes.Internal, "internal error"), metadata.Pairs("key", "val"))
+			if err := f.FormatTrailer(status.New(codes.Internal, "internal error"), metadata.Pairs("key", "val")); err != nil {
+				t.Fatalf("FormatTrailer should not return an error, but got '%s'", err)
+			}
 			if err := f.Done(); err != nil {
 				t.Fatalf("Done should not return an error, but got '%s'", err)
 			}

--- a/format/json/json.go
+++ b/format/json/json.go
@@ -2,11 +2,16 @@
 package json
 
 import (
+	"bytes"
+	gojson "encoding/json"
 	"io"
 
+	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck
+	"github.com/golang/protobuf/proto"  //nolint:staticcheck
 	"github.com/ktr0731/evans/format"
 	"github.com/ktr0731/evans/present"
 	"github.com/ktr0731/evans/present/json"
+	_ "google.golang.org/genproto/googleapis/rpc/errdetails" // For calling RegisterType.
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -15,20 +20,22 @@ import (
 type responseFormatter struct {
 	w io.Writer
 	s struct {
-		Status *struct {
-			Code    string `json:"code"`
-			Number  uint32 `json:"number"`
-			Message string `json:"message"`
+		Status struct {
+			Code    string        `json:"code"`
+			Number  uint32        `json:"number"`
+			Message string        `json:"message"`
+			Details []interface{} `json:"details,omitempty"`
 		} `json:"status,omitempty"`
-		Header   *metadata.MD  `json:"header,omitempty"`
-		Messages []interface{} `json:"messages,omitempty"`
-		Trailer  *metadata.MD  `json:"trailer,omitempty"`
+		Header   *metadata.MD             `json:"header,omitempty"`
+		Messages []map[string]interface{} `json:"messages,omitempty"`
+		Trailer  *metadata.MD             `json:"trailer,omitempty"`
 	}
-	p present.Presenter
+	p           present.Presenter
+	pbMarshaler *jsonpb.Marshaler
 }
 
 func NewResponseFormatter(w io.Writer) format.ResponseFormatterInterface {
-	return &responseFormatter{w: w, p: json.NewPresenter("  ")}
+	return &responseFormatter{w: w, p: json.NewPresenter("  "), pbMarshaler: &jsonpb.Marshaler{}}
 }
 
 func (p *responseFormatter) FormatHeader(header metadata.MD) {
@@ -36,7 +43,11 @@ func (p *responseFormatter) FormatHeader(header metadata.MD) {
 }
 
 func (p *responseFormatter) FormatMessage(v interface{}) error {
-	p.s.Messages = append(p.s.Messages, v)
+	m, err := p.convertProtoMessageToMap(v.(proto.Message))
+	if err != nil {
+		return err
+	}
+	p.s.Messages = append(p.s.Messages, m)
 	return nil
 }
 
@@ -44,12 +55,35 @@ func (p *responseFormatter) FormatTrailer(trailer metadata.MD) {
 	p.s.Trailer = &trailer
 }
 
-func (p *responseFormatter) FormatStatus(s *status.Status) {
-	p.s.Status = &struct {
-		Code    string `json:"code"`
-		Number  uint32 `json:"number"`
-		Message string `json:"message"`
-	}{s.Code().String(), uint32(s.Code()), s.Message()}
+func (p *responseFormatter) FormatStatus(s *status.Status) error {
+	var details []interface{}
+	if len(s.Details()) != 0 {
+		details = make([]interface{}, 0, len(s.Details()))
+		for _, d := range s.Details() {
+			d, ok := d.(proto.Message)
+			if !ok {
+				continue
+			}
+			m, err := p.convertProtoMessageToMap(d)
+			if err != nil {
+				return err
+			}
+			details = append(details, m)
+		}
+	}
+
+	p.s.Status = struct {
+		Code    string        `json:"code"`
+		Number  uint32        `json:"number"`
+		Message string        `json:"message"`
+		Details []interface{} `json:"details,omitempty"`
+	}{
+		Code:    s.Code().String(),
+		Number:  uint32(s.Code()),
+		Message: s.Message(),
+		Details: details,
+	}
+	return nil
 }
 
 func (p *responseFormatter) Done() error {
@@ -59,4 +93,17 @@ func (p *responseFormatter) Done() error {
 	}
 	_, err = io.WriteString(p.w, s+"\n")
 	return err
+}
+
+func (p *responseFormatter) convertProtoMessageToMap(m proto.Message) (map[string]interface{}, error) {
+	var buf bytes.Buffer
+	err := p.pbMarshaler.Marshal(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+	var res map[string]interface{}
+	if err := gojson.Unmarshal(buf.Bytes(), &res); err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
-	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
+	github.com/golang/protobuf v1.4.0
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
@@ -17,7 +17,7 @@ require (
 	github.com/ktr0731/go-prompt v0.2.2-0.20190609072126-7894cc3f2925
 	github.com/ktr0731/go-shellstring v0.1.3
 	github.com/ktr0731/go-updater v0.1.5
-	github.com/ktr0731/grpc-test v0.1.6
+	github.com/ktr0731/grpc-test v0.1.7
 	github.com/ktr0731/grpc-web-go-client v0.2.6
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/manifoldco/promptui v0.7.0
@@ -43,11 +43,10 @@ require (
 	github.com/zchee/go-xdgbasedir v1.0.3
 	go.uber.org/goleak v0.10.0
 	golang.org/x/mod v0.2.0 // indirect
-	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
+	golang.org/x/sys v0.0.0-20200428200454-593003d681fa // indirect
 	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd
-	google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb
+	google.golang.org/genproto v0.0.0-20200428115010-c45acf45369a
 	google.golang.org/grpc v1.29.1
-	google.golang.org/protobuf v1.21.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ktr0731/go-shellstring v0.1.3
 	github.com/ktr0731/go-updater v0.1.5
 	github.com/ktr0731/grpc-test v0.1.7
-	github.com/ktr0731/grpc-web-go-client v0.2.6
+	github.com/ktr0731/grpc-web-go-client v0.2.7
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mattn/go-colorable v0.1.6

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
-	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.12
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
-	github.com/golang/protobuf v1.4.0
+	github.com/gogo/protobuf v1.3.1
+	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
@@ -47,6 +48,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
 	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd
-	google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb // indirect
+	google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0 h1:aRz0NBceriICVtjhCgKkDvl+RudKu1CT6h0ZvUTrNfE=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
+github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
+github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -145,8 +147,8 @@ github.com/ktr0731/go-updater v0.1.5 h1:AiaQxJoI0OTGqvsJYdIITCOaEzQQOqU2MHKUwttV
 github.com/ktr0731/go-updater v0.1.5/go.mod h1:dsdOg7a9sj6ttcOU5ZxPCtKdm9WeB1hwcX/7oKgz9/0=
 github.com/ktr0731/grpc-test v0.1.4 h1:FtZtbAUcQY1nye7zwwjZBT8usJkusWF0+Gtq+UlHyGU=
 github.com/ktr0731/grpc-test v0.1.4/go.mod h1:v47616grayBYXQveGWxO3OwjLB3nEEnHsZuMTc73FM0=
-github.com/ktr0731/grpc-test v0.1.6 h1:7ZCW1pvdl6U4venUR4tdToZmHwgsYn+AANVNIt36B+o=
-github.com/ktr0731/grpc-test v0.1.6/go.mod h1:ue5vSP5X8I3SyYIMXFh5DfIoIGajEX7IWNLNSmZImhI=
+github.com/ktr0731/grpc-test v0.1.7 h1:QwjxlKMHb1FzQMoXjjK1F2HDdIf5f72WXWZs4He8nNI=
+github.com/ktr0731/grpc-test v0.1.7/go.mod h1:vjMPOfGerucM+ysAKiynHDS6IUSErB6O9gBOHWyUs5s=
 github.com/ktr0731/grpc-web-go-client v0.2.6 h1:lt52qtjeayppBzr13L5RZdNhRIPD0D4udmWX1+lWaQA=
 github.com/ktr0731/grpc-web-go-client v0.2.6/go.mod h1:OMPf98saG1hxdh0lWY+GXvQaZ/944WEwDCCjuGebPYw=
 github.com/ktr0731/modfile v1.11.2 h1:TRz8W9M0W2sRbPf/tainqLkwE9bUQ4anGqZN8A8nymw=
@@ -304,8 +306,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
-golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -328,8 +330,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200428200454-593003d681fa h1:yMbJOvnfYkO1dSAviTu/ZguZWLBTXx4xE3LYrxUCCiA=
+golang.org/x/sys v0.0.0-20200428200454-593003d681fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -356,8 +358,8 @@ google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200204235621-fb4a7afc5178/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
-google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb h1:nAFaltAMbNVA0rixtwvdnqgSVLX3HFUUvMkEklmzbYM=
-google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200428115010-c45acf45369a h1:ykRcNp3dotYGpAEIYeWCGaefklVjVy/rnSvM3zNh6j8=
+google.golang.org/genproto v0.0.0-20200428115010-c45acf45369a/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/go.sum
+++ b/go.sum
@@ -71,9 +71,8 @@ github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
+github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0 h1:aRz0NBceriICVtjhCgKkDvl+RudKu1CT6h0ZvUTrNfE=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
-github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
-github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -366,10 +365,6 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
-google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
-google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/ktr0731/grpc-test v0.1.4 h1:FtZtbAUcQY1nye7zwwjZBT8usJkusWF0+Gtq+UlHy
 github.com/ktr0731/grpc-test v0.1.4/go.mod h1:v47616grayBYXQveGWxO3OwjLB3nEEnHsZuMTc73FM0=
 github.com/ktr0731/grpc-test v0.1.7 h1:QwjxlKMHb1FzQMoXjjK1F2HDdIf5f72WXWZs4He8nNI=
 github.com/ktr0731/grpc-test v0.1.7/go.mod h1:vjMPOfGerucM+ysAKiynHDS6IUSErB6O9gBOHWyUs5s=
-github.com/ktr0731/grpc-web-go-client v0.2.6 h1:lt52qtjeayppBzr13L5RZdNhRIPD0D4udmWX1+lWaQA=
-github.com/ktr0731/grpc-web-go-client v0.2.6/go.mod h1:OMPf98saG1hxdh0lWY+GXvQaZ/944WEwDCCjuGebPYw=
+github.com/ktr0731/grpc-web-go-client v0.2.7 h1:Op1U1XC29kb7S8XptqYd742JwcG7oR5Q7QoYPZMN2T4=
+github.com/ktr0731/grpc-web-go-client v0.2.7/go.mod h1:1Iac8gFJvC/DRfZoGnFZsfEbEq/wQFK+2Ve1o3pHkCQ=
 github.com/ktr0731/modfile v1.11.2 h1:TRz8W9M0W2sRbPf/tainqLkwE9bUQ4anGqZN8A8nymw=
 github.com/ktr0731/modfile v1.11.2/go.mod h1:LzNwnHJWHbuDh3BO17lIqzqDldXqGu1HCydWH3SinE0=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=


### PR DESCRIPTION
Evans now supports status details (e.g. `errdetails`).
`call` command with `--enrich` flag displays status details if it was sent.