### PR TITLE
feat: add grpc-timeout to unary and server streaming calls

### DIFF
--- a/usecase/call_rpc.go
+++ b/usecase/call_rpc.go
@@ -129,7 +129,15 @@ func (m *dependencyManager) CallRPC(ctx context.Context, w io.Writer, rpcName st
 			return nil, err
 		}
 
-		ctx, _ = context.WithTimeout(ctx, timeout)
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+
+		go func() {
+			t := time.NewTicker(timeout)
+			select {
+			case <-t.C:
+				cancel()
+			}
+		}()
 
 		return ctx, nil
 	}

--- a/usecase/call_rpc.go
+++ b/usecase/call_rpc.go
@@ -133,10 +133,8 @@ func (m *dependencyManager) CallRPC(ctx context.Context, w io.Writer, rpcName st
 
 		go func() {
 			t := time.NewTicker(timeout)
-			select {
-			case <-t.C:
-				cancel()
-			}
+			<-t.C
+			cancel()
 		}()
 
 		return ctx, nil


### PR DESCRIPTION
Fix #291 

- Add `grpc-timeout` header to unary calls and server streaming calls

Let me know for any improvements. Thank you!