### PR TITLE
fix PROTOCOL_ERROR when sending headers to reflection client

### DIFF
--- a/grpc/grpcreflection/reflection.go
+++ b/grpc/grpcreflection/reflection.go
@@ -37,7 +37,11 @@ type client struct {
 }
 
 func getCtx(headers map[string][]string) context.Context {
-	return metadata.NewOutgoingContext(context.Background(), metadata.MD(headers))
+	md := metadata.New(nil)
+	for k, v := range headers {
+		md.Append(k, v...)
+	}
+	return metadata.NewOutgoingContext(context.Background(), md)
 }
 
 // NewClient returns an instance of gRPC reflection client for gRPC protocol.


### PR DESCRIPTION
This relates to #351.

Unfortunately when addressing the comments I didn't test the changes as they seemed innocuous enough, however, it seems that they broke something internal to the GRPC protocol.

At least with traefik, when sending headers to the reflection client with evans 0.9.2 you get the following error message:

```
evans: failed to run REPL mode: failed to instantiate a new spec: failed to instantiate the spec: failed to list packages by gRPC reflection: failed to list services from reflecton enabled gRPC server: rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR
```

On traefik side you can see:

```
server.go:648: http2: server connection error from X.Y.Z.A:58312: connection error: PROTOCOL_ERROR
```

To be honest, I am not sure I understand the issue but the fix is simple enough. Looking at the code of what `metadata.New` and what the `Append` method does I suspect the issue is related to the headers not being lower cased. For instance, this is what the `New` function does:

``` go
func New(m map[string]string) MD {
	md := MD{}
	for k, val := range m {
		key := strings.ToLower(k)
		md[key] = append(md[key], val)
	}
	return md
}
```

So I guess casting isn't enough.