### PR TITLE
go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ $ brew tap ktr0731/evans
 $ brew install evans
 ```
 
-### **[Not-recommended]** go get
-Go v1.13 (with mod-aware mode) or later is required.  
-`go get` installation is not supported officially.
+### **[Not-recommended]** go install
+
+Go v1.16 or later is required.  
+
 ``` sh
-$ go get github.com/ktr0731/evans
+$ go install github.com/ktr0731/evans@latest
 ```
 
 ## Usage (REPL)


### PR DESCRIPTION
The official doc says:

https://golang.org/doc/go-get-install-deprecation

> Starting in Go 1.17, installing executables with go get is deprecated. 

In order to use "go install", the requirement of the minimum version should also be updated. (v1.13 -> v1.16)

I think this change will help users who prefer using `go install` to brew tap.

