### PR TITLE
add prefix for enum type

### DIFF
--- a/fill/proto/interactive_filler.go
+++ b/fill/proto/interactive_filler.go
@@ -152,7 +152,7 @@ func (r *resolver) resolveField(f *desc.FieldDescriptor) error {
 			)
 			return msgr.resolve()
 		case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
-			return r.resolveEnum(f.GetEnumType())
+			return r.resolveEnum(r.makePrefix(f), f.GetEnumType())
 		case descriptorpb.FieldDescriptorProto_TYPE_DOUBLE:
 			converter = func(v string) (interface{}, error) { return strconv.ParseFloat(v, 64) }
 
@@ -254,13 +254,13 @@ func (r *resolver) resolveField(f *desc.FieldDescriptor) error {
 	}
 }
 
-func (r *resolver) resolveEnum(e *desc.EnumDescriptor) (int32, error) {
+func (r *resolver) resolveEnum(prefix string, e *desc.EnumDescriptor) (int32, error) {
 	choices := make([]string, 0, len(e.GetValues()))
 	for _, v := range e.GetValues() {
 		choices = append(choices, v.GetName())
 	}
 
-	choice, err := r.selectChoices(e.GetFullyQualifiedName(), choices)
+	choice, err := r.selectChoices(prefix, choices)
 	if err != nil {
 		return 0, err
 	}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -2,6 +2,7 @@
 package prompt
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -87,7 +88,11 @@ func newPrompt(opts ...Option) Prompt {
 		InputFunc:   goprompt.Input,
 		prefixColor: ColorInitial,
 		SelectFunc: func(message string, options []string) (int, string, error) {
-			s := promptui.Select{Label: message, Items: options}
+			s := promptui.Select{
+				Label:     message,
+				Items:     options,
+				Templates: &promptui.SelectTemplates{Label: fmt.Sprintf("%s {{.}}", promptui.IconInitial)},
+			}
 			return s.Run()
 		},
 		commandHistory: opt.commandHistory,


### PR DESCRIPTION
For multiple fields of the same enum type in a proto message, it's confusing not to prompt which field to enter...

After the change:
![image](https://user-images.githubusercontent.com/11025519/143182469-a35c2bbb-ddea-48a4-9c2b-b291f570af5f.png)
