### PR TITLE
Resolve enum selection with the field number

### DIFF
--- a/fill/proto/interactive_filler.go
+++ b/fill/proto/interactive_filler.go
@@ -265,7 +265,9 @@ func (r *resolver) resolveEnum(prefix string, e *desc.EnumDescriptor) (int32, er
 		return 0, err
 	}
 
-	return int32(choice), nil
+	value := e.GetValues()[choice].AsEnumValueDescriptorProto()
+
+	return *value.Number, nil
 }
 
 func (r *resolver) input(prefix string, f *desc.FieldDescriptor, converter func(string) (interface{}, error)) (interface{}, error) {


### PR DESCRIPTION
## Why

The current implementation resolves the enum value in REPL with the index of selection; It only works if the entries are numbered continuously and zero-based.
If we select `BRAVO`, for instance, the request object is created with a value of `1` in both cases.

```proto
enum Foo {
    ALPHA = 0;
    BRAVO = 1;
    CHARLIE = 2;
    DELTA = 3;
}
```

```proto
enum Foo {
    ALPHA = 2;
    BRAVO = 3;
    CHARLIE = 5;
    DELTA = 8;
}
```

