### PR TITLE
specify custom resolver

### DIFF
--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_and_json_format.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_and_json_format.golden
@@ -22,6 +22,14 @@
             "type": "type"
           }
         ]
+      },
+      {
+        "@type": "type.googleapis.com/api.FailureDetail",
+        "code": "001"
+      },
+      {
+        "@type": "type.googleapis.com/api.IndependentFailureDetail",
+        "code": "BAR"
       }
     ]
   },

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag.golden
@@ -11,4 +11,6 @@ message: "internal error"
 details: 
   {"@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [{"description": "description", "field": "field"}]}
   {"@type": "type.googleapis.com/google.rpc.PreconditionFailure", "violations": [{"description": "description", "subject": "subject", "type": "type"}]}
+  {"@type": "type.googleapis.com/api.FailureDetail", "code": "001"}
+  {"@type": "type.googleapis.com/api.IndependentFailureDetail", "code": "BAR"}
 

--- a/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-call_failure_unary_rpc_with_--enrich_flag_against_to_grpc-web_server.golden
@@ -12,4 +12,6 @@ message: "internal error"
 details: 
   {"@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [{"description": "description", "field": "field"}]}
   {"@type": "type.googleapis.com/google.rpc.PreconditionFailure", "violations": [{"description": "description", "subject": "subject", "type": "type"}]}
+  {"@type": "type.googleapis.com/api.FailureDetail", "code": "001"}
+  {"@type": "type.googleapis.com/api.IndependentFailureDetail", "code": "BAR"}
 

--- a/e2e/testdata/fixtures/teste2e_repl-call_unaryheadertrailerfailure_by_selecting_package_and_service_with_enriched_output.golden
+++ b/e2e/testdata/fixtures/teste2e_repl-call_unaryheadertrailerfailure_by_selecting_package_and_service_with_enriched_output.golden
@@ -13,5 +13,7 @@ message: "internal error"
 details: 
   {"@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [{"description": "description", "field": "field"}]}
   {"@type": "type.googleapis.com/google.rpc.PreconditionFailure", "violations": [{"description": "description", "subject": "subject", "type": "type"}]}
+  {"@type": "type.googleapis.com/api.FailureDetail", "code": "001"}
+  {"@type": "type.googleapis.com/api.IndependentFailureDetail", "code": "BAR"}
 
 

--- a/format/format.go
+++ b/format/format.go
@@ -2,9 +2,14 @@
 package format
 
 import (
+	pb "github.com/ktr0731/evans/proto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// DescriptorSource will be injected at runtime.
+// TODO: Modify to avoid using global variable.
+var DescriptorSource pb.DescriptorSource
 
 // ResponseFormatter provides formatting feature for gRPC response.
 type ResponseFormatter struct {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ktr0731/go-prompt v0.2.4
 	github.com/ktr0731/go-shellstring v0.1.3
 	github.com/ktr0731/go-updater v0.1.5
-	github.com/ktr0731/grpc-test v0.1.10
+	github.com/ktr0731/grpc-test v0.1.12
 	github.com/ktr0731/grpc-web-go-client v0.2.8
 	github.com/manifoldco/promptui v0.9.0
 	github.com/matryer/moq v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -731,8 +731,8 @@ github.com/ktr0731/go-shellstring v0.1.3/go.mod h1:f0/XX0hsm6A02Es/UDQ9MGd3VqpCH
 github.com/ktr0731/go-updater v0.1.5 h1:AiaQxJoI0OTGqvsJYdIITCOaEzQQOqU2MHKUwttVShY=
 github.com/ktr0731/go-updater v0.1.5/go.mod h1:dsdOg7a9sj6ttcOU5ZxPCtKdm9WeB1hwcX/7oKgz9/0=
 github.com/ktr0731/grpc-test v0.1.4/go.mod h1:v47616grayBYXQveGWxO3OwjLB3nEEnHsZuMTc73FM0=
-github.com/ktr0731/grpc-test v0.1.10 h1:W+fdfNrcSY0+9aiIIx+CWpFcNjdcqysPQchDcuMk4Pk=
-github.com/ktr0731/grpc-test v0.1.10/go.mod h1:AP4+ZrqSzdDaUNhAsp2fye06MXO2fdYY6YQJifb588M=
+github.com/ktr0731/grpc-test v0.1.12 h1:Yha+zH2hB48huOfbsEMfyG7FeHCrVWq4fYmHfr3iH3U=
+github.com/ktr0731/grpc-test v0.1.12/go.mod h1:AP4+ZrqSzdDaUNhAsp2fye06MXO2fdYY6YQJifb588M=
 github.com/ktr0731/grpc-web-go-client v0.2.8 h1:nUf9p+YWirmFwmH0mwtAWhuXvzovc+/3C/eAY2Fshnk=
 github.com/ktr0731/grpc-web-go-client v0.2.8/go.mod h1:1Iac8gFJvC/DRfZoGnFZsfEbEq/wQFK+2Ve1o3pHkCQ=
 github.com/ktr0731/modfile v1.11.2/go.mod h1:LzNwnHJWHbuDh3BO17lIqzqDldXqGu1HCydWH3SinE0=

--- a/mode/cli.go
+++ b/mode/cli.go
@@ -198,6 +198,10 @@ func RunAsCLIMode(cfg *config.Config, invoker CLIInvoker) error {
 		injectResult = multierror.Append(injectResult, err)
 	}
 
+	if err := registerDescriptorSource(cfg, gRPCClient); err != nil {
+		injectResult = multierror.Append(injectResult, err)
+	}
+
 	if injectResult != nil {
 		return injectResult
 	}

--- a/mode/common.go
+++ b/mode/common.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 
 	"github.com/ktr0731/evans/config"
+	"github.com/ktr0731/evans/format"
 	"github.com/ktr0731/evans/grpc"
 	"github.com/ktr0731/evans/grpc/grpcreflection"
 	"github.com/ktr0731/evans/idl"
 	"github.com/ktr0731/evans/idl/proto"
+	pb "github.com/ktr0731/evans/proto"
 	"github.com/ktr0731/evans/usecase"
 	"github.com/pkg/errors"
 )
@@ -46,6 +48,21 @@ func newGRPCClient(cfg *config.Config) (grpc.Client, error) {
 		return nil, errors.Wrap(err, "failed to instantiate a gRPC client")
 	}
 	return client, nil
+}
+
+func registerDescriptorSource(cfg *config.Config, client grpcreflection.Client) error {
+	if cfg.Server.Reflection {
+		format.DescriptorSource = pb.NewDescriptorSourceFromReflection(client)
+		return nil
+	}
+
+	ds, err := pb.NewDescriptorSourceFromFiles(cfg.Default.ProtoPath, cfg.Default.ProtoFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to new descriptor source from files")
+	}
+	format.DescriptorSource = ds
+
+	return nil
 }
 
 func gRPCReflectionPackageFilteredPackages(pkgNames []string) []string {

--- a/mode/repl.go
+++ b/mode/repl.go
@@ -28,6 +28,10 @@ func RunAsREPLMode(cfg *config.Config, ui cui.UI, cache *cache.Cache) error {
 		return errors.Wrap(err, "failed to instantiate a new spec")
 	}
 
+	if err := registerDescriptorSource(cfg, gRPCClient); err != nil {
+		return errors.Wrap(err, "failed to register descriptor source")
+	}
+
 	usecase.Inject(
 		usecase.Dependencies{
 			Spec:              spec,

--- a/proto/descsource.go
+++ b/proto/descsource.go
@@ -1,0 +1,75 @@
+package proto
+
+import (
+	"fmt"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+type DescriptorSource interface {
+	FindSymbol(name string) (protoreflect.MessageDescriptor, error)
+}
+
+type reflection struct {
+	client messageTypeRegistry
+}
+
+type messageTypeRegistry interface {
+	FindSymbol(name string) (protoreflect.MessageDescriptor, error)
+}
+
+func NewDescriptorSourceFromReflection(c messageTypeRegistry) DescriptorSource {
+	return &reflection{c}
+}
+
+func (r *reflection) FindSymbol(name string) (protoreflect.MessageDescriptor, error) {
+	return r.client.FindSymbol(name)
+}
+
+type files struct {
+	fds []*desc.FileDescriptor
+}
+
+func NewDescriptorSourceFromFiles(importPaths []string, fnames []string) (DescriptorSource, error) {
+	p := &protoparse.Parser{
+		ImportPaths: importPaths,
+	}
+	fds, err := p.ParseFiles(fnames...)
+	if err != nil {
+		return nil, errors.Wrap(err, "proto: failed to parse passed proto files")
+	}
+
+	return &files{fds: fds}, nil
+}
+
+var errSymbolNotFound = errors.New("proto: symbol not found")
+
+func (f *files) FindSymbol(name string) (protoreflect.MessageDescriptor, error) {
+	for _, fd := range f.fds {
+		d := fd.FindSymbol(name)
+		if d == nil {
+			continue
+		}
+
+		if err := RegisterFileAndType(fd); err != nil {
+			return nil, errors.Wrap(err, "failed to register file dscriptor")
+		}
+
+		fd, err := protodesc.NewFile(fd.AsFileDescriptorProto(), protoregistry.GlobalFiles)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to find file containing symbol %s", name)
+		}
+
+		md := fd.Messages().ByName(protoreflect.FullName(name).Name())
+		if md == nil {
+			return nil, fmt.Errorf("failed to find message '%s'", name)
+		}
+	}
+
+	return nil, errSymbolNotFound
+}

--- a/proto/registry.go
+++ b/proto/registry.go
@@ -1,0 +1,88 @@
+package proto
+
+import (
+	"strings"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+func RegisterFileAndType(fd *desc.FileDescriptor) error {
+	deps := fd.GetDependencies()
+	for _, d := range deps {
+		if err := RegisterFileAndType(d); err != nil {
+			return err
+		}
+	}
+
+	prfd, err := protodesc.NewFile(fd.AsFileDescriptorProto(), protoregistry.GlobalFiles)
+	if err != nil {
+		return errors.Wrap(err, "failed to new file descriptor")
+	}
+
+	if _, err := protoregistry.GlobalFiles.FindFileByPath(prfd.Path()); errors.Is(err, protoregistry.NotFound) {
+		if err := protoregistry.GlobalFiles.RegisterFile(prfd); err != nil {
+			return err
+		}
+	}
+
+	for i := 0; i < prfd.Messages().Len(); i++ {
+		md := prfd.Messages().Get(i)
+		if _, err := protoregistry.GlobalTypes.FindMessageByName(md.FullName()); errors.Is(err, protoregistry.NotFound) {
+			if err := protoregistry.GlobalTypes.RegisterMessage(dynamicpb.NewMessageType(md)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type anyResolver struct {
+	protoregistry.ExtensionTypeResolver
+	descSource DescriptorSource
+}
+
+func NewAnyResolver(descSource DescriptorSource) interface {
+	protoregistry.ExtensionTypeResolver
+	protoregistry.MessageTypeResolver
+} {
+	return &anyResolver{
+		descSource: descSource,
+	}
+}
+
+func (r *anyResolver) FindMessageByName(m protoreflect.FullName) (protoreflect.MessageType, error) {
+	md, err := r.descSource.FindSymbol(string(m))
+	if err != nil {
+		return nil, err
+	}
+	if errors.Is(err, errSymbolNotFound) {
+		// Fallback to protoregistry.GlobalTypes.
+		return protoregistry.GlobalTypes.FindMessageByName(m)
+	}
+
+	return dynamicpb.NewMessageType(md), nil
+}
+
+func (r *anyResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	n := strings.LastIndex(url, "/")
+	if n != -1 {
+		url = url[n+1:]
+	}
+
+	md, err := r.descSource.FindSymbol(url)
+	if err != nil && !errors.Is(err, errSymbolNotFound) {
+		return nil, err
+	}
+	if errors.Is(err, errSymbolNotFound) {
+		// Fallback to protoregistry.GlobalTypes.
+		return protoregistry.GlobalTypes.FindMessageByURL(url)
+	}
+
+	return dynamicpb.NewMessageType(md), nil
+}


### PR DESCRIPTION
Currently, messages will be decode/encoded with only `protoregistry.GlobalTypes`. However, it's possible to receive a message which is not registered in `protoregistry.GlobalTypes` (e.g. `grpc-status-details-bin`).
This PR makes the resolver specify "descriptor source" such as gRPC reflection or file descriptors.