### PR TITLE
Extend the error message to give hint to user about reason for error

### DIFF
--- a/fill/filler.go
+++ b/fill/filler.go
@@ -4,7 +4,7 @@ package fill
 import "errors"
 
 var (
-	ErrCodecMismatch = errors.New("unsupported codec")
+	ErrCodecMismatch = errors.New("unsupported codec (could be invalid JSON format)")
 )
 
 // Filler tries to correspond input text to a struct.


### PR DESCRIPTION
Came across this message myself because of accidental invalid JSON format and this is also consistent with code comment in fill/silent_filler.go#L22