### PR TITLE
🔧 Fix: no update

### DIFF
--- a/app/update.go
+++ b/app/update.go
@@ -60,17 +60,17 @@ func checkUpdate(ctx context.Context, cfg *config.Config, c *cache.Cache) error 
 		}
 	}
 
-	u := newUpdater(cfg, meta.Version, m)
-	updatable, latest, err := u.Updatable(ctx)
-	if errors.Cause(err) != context.Canceled && err != nil {
-		return errors.Wrap(err, "failed to check updatable")
-	}
-	if updatable {
-		c.UpdateInfo.LatestVersion = latest.String()
-		if err := c.Save(); err != nil {
-			return errors.Wrap(err, "failed to save a cache")
-		}
-	}
+	// u := newUpdater(cfg, meta.Version, m)
+	// updatable, latest, err := u.Updatable(ctx)
+	// if errors.Cause(err) != context.Canceled && err != nil {
+	// 	return errors.Wrap(err, "failed to check updatable")
+	// }
+	// if updatable {
+	// 	c.UpdateInfo.LatestVersion = latest.String()
+	// 	if err := c.Save(); err != nil {
+	// 		return errors.Wrap(err, "failed to save a cache")
+	// 	}
+	// }
 	return nil
 }
 


### PR DESCRIPTION
エラーになるので、いったん無効化しちゃう
```
adamant.teller.v1.TellerAPI@127.0.0.1:50051> panic: Malformed version: stable

goroutine 5 [running]:
github.com/hashicorp/go-version.Must(...)
	/Users/akokubu/.asdf/installs/golang/1.18/packages/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:102
github.com/ktr0731/go-updater/brew.(*HomebrewClient).LatestTag(0x140001140f0, {0x100fe99c8?, 0x14000044200?})
	/Users/akokubu/.asdf/installs/golang/1.18/packages/pkg/mod/github.com/ktr0731/go-updater@v0.1.5/brew/brew.go:66 +0x428
github.com/ktr0731/go-updater.(*Updater).Updatable(0x14000114120, {0x100fe99c8?, 0x14000044200?})
	/Users/akokubu/.asdf/installs/golang/1.18/packages/pkg/mod/github.com/ktr0731/go-updater@v0.1.5/updater.go:48 +0x44
github.com/ktr0731/evans/app.checkUpdate({0x100fe99c8, 0x14000044200}, 0x0?, 0x140000ca0a0)
	/Users/akokubu/ghq/github.com/akokubu/evans/app/update.go:64 +0x184
github.com/ktr0731/evans/app.runREPLCommand.func1()
	/Users/akokubu/ghq/github.com/akokubu/evans/app/commands.go:269 +0x34
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/Users/akokubu/.asdf/installs/golang/1.18/packages/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/errgroup/errgroup.go:75 +0x60
created by golang.org/x/sync/errgroup.(*Group).Go
	/Users/akokubu/.asdf/installs/golang/1.18/packages/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/errgroup/errgroup.go:72 +0xa8
```