### PR TITLE
update ktr0731/go-updater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ktr0731/go-multierror v0.0.0-20171204182908-b7773ae21874
 	github.com/ktr0731/go-prompt v0.2.4
 	github.com/ktr0731/go-shellstring v0.1.3
-	github.com/ktr0731/go-updater v0.1.5
+	github.com/ktr0731/go-updater v0.1.6
 	github.com/ktr0731/grpc-test v0.1.10
 	github.com/ktr0731/grpc-web-go-client v0.2.8
 	github.com/manifoldco/promptui v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/ktr0731/go-prompt v0.2.4/go.mod h1:sOMZT/OLHdKWungRcm7ZG45OVq+2/Ea7zJ
 github.com/ktr0731/go-semver v0.1.1/go.mod h1:gE6cyNMdgKcUY/d9tdlZDqiLYPixpJcZh3addTcQSp4=
 github.com/ktr0731/go-shellstring v0.1.3 h1:PH3Y2SHbdBF5G9+XrRlT3Dpgl/2CzQHIqFOOBz6Nco8=
 github.com/ktr0731/go-shellstring v0.1.3/go.mod h1:f0/XX0hsm6A02Es/UDQ9MGd3VqpCHrCw5pMjE2y6qTU=
-github.com/ktr0731/go-updater v0.1.5 h1:AiaQxJoI0OTGqvsJYdIITCOaEzQQOqU2MHKUwttVShY=
-github.com/ktr0731/go-updater v0.1.5/go.mod h1:dsdOg7a9sj6ttcOU5ZxPCtKdm9WeB1hwcX/7oKgz9/0=
+github.com/ktr0731/go-updater v0.1.6 h1:GW88jEdipFqCmPf9bJNg/jSp4CKDZyakxG32MjlchJ8=
+github.com/ktr0731/go-updater v0.1.6/go.mod h1:dsdOg7a9sj6ttcOU5ZxPCtKdm9WeB1hwcX/7oKgz9/0=
 github.com/ktr0731/grpc-test v0.1.4/go.mod h1:v47616grayBYXQveGWxO3OwjLB3nEEnHsZuMTc73FM0=
 github.com/ktr0731/grpc-test v0.1.10 h1:W+fdfNrcSY0+9aiIIx+CWpFcNjdcqysPQchDcuMk4Pk=
 github.com/ktr0731/grpc-test v0.1.10/go.mod h1:AP4+ZrqSzdDaUNhAsp2fye06MXO2fdYY6YQJifb588M=


### PR DESCRIPTION
This fixes #577 

The newer Homebrew changed the output of `brew info ktr0731/evans/evans`. This change fixes the auto-update feature.