### PR TITLE
Fix how to start REPL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The proto file which read in the demonstration and its implementation are availa
 Enter to REPL.
 ``` sh
 cd grpc-test
-evans repl api/api.proto
+evans --proto api/api.proto repl
 ```
 
 If your server is enabling [gRPC reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md), you can launch Evans with only `-r` (`--reflection`) option.


### PR DESCRIPTION
I got a following error message in the previous way to start REPL.

```
% evans repl path/to/api.proto
evans 0.10.9

Usage: evans [global options ...] repl [options ...]

Options:
        --package string        default package
        --service string        default service
        --help, -h              display help text and exit (default "false")

evans: invalid config condition: 1 error occurred:

* one or more proto files, or gRPC reflection required
```