### PR TITLE
Fix bug with server stream of bytes

### DIFF
--- a/format/curl/curl.go
+++ b/format/curl/curl.go
@@ -145,7 +145,8 @@ func (p *responseFormatter) convertProtoMessageToMap(m proto.Message) (map[strin
 	}
 	var res map[string]interface{}
 	if err := gojson.Unmarshal(buf.Bytes(), &res); err != nil {
-		return nil, err
+		fmt.Println(buf.String())
+		return nil, nil
 	}
 	return res, nil
 }


### PR DESCRIPTION
Fix issue #599 
With this change when gojson library cannot unmarshal message from server (which is the case for server side streaming of bytes), then it will display it in base64 format.