### PR TITLE
bump to v0.10.11

### DIFF
--- a/config/testdata/fixtures/create_a_default_global_config_if_both_of_global_and_local_config_are_not_found.golden.toml
+++ b/config/testdata/fixtures/create_a_default_global_config_if_both_of_global_and_local_config_are_not_found.golden.toml
@@ -10,7 +10,7 @@
 
 [meta]
   autoupdate = false
-  configversion = "0.10.10"
+  configversion = "0.10.11"
   updatelevel = "patch"
 
 [repl]

--- a/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_call_command_usage.golden
@@ -1,4 +1,4 @@
-evans 0.10.10
+evans 0.10.11
 
 Usage: evans [global options ...] cli call [options ...] <method>
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_desc_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_desc_command_usage.golden
@@ -1,4 +1,4 @@
-evans 0.10.10
+evans 0.10.11
 
 Usage: evans [global options ...] cli desc [options ...] [symbol]
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_list_command_usage.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_list_command_usage.golden
@@ -1,4 +1,4 @@
-evans 0.10.10
+evans 0.10.11
 
 Usage: evans [global options ...] cli list [options ...] [fully-qualified service/method name]
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer.golden
@@ -1,4 +1,4 @@
-evans 0.10.10
+evans 0.10.11
 
 Usage: evans [global options ...] cli
 

--- a/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
+++ b/e2e/testdata/fixtures/teste2e_cli-print_usage_text_to_the_writer_(common_flag).golden
@@ -1,4 +1,4 @@
-evans 0.10.10
+evans 0.10.11
 
 Usage: evans [global options ...] cli
 

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -5,5 +5,5 @@ import version "github.com/hashicorp/go-version"
 const AppName = "evans"
 
 var (
-	Version = version.Must(version.NewSemver("0.10.10"))
+	Version = version.Must(version.NewSemver("0.10.11"))
 )


### PR DESCRIPTION
These are the same changes in v0.10.10, but re-create a new release since it seems like Homebrew tap is broken.