### PR TITLE
add support for gRPC services exposed locally via UNIX sockets

### DIFF
--- a/mode/common.go
+++ b/mode/common.go
@@ -13,7 +13,13 @@ import (
 )
 
 func newGRPCClient(cfg *config.Config) (grpc.Client, error) {
-	addr := fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port)
+	var addr string
+	if strings.HasPrefix(cfg.Server.Host, "unix://") {
+		addr = cfg.Server.Host
+	} else {
+		addr = fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port)
+	}
+
 	if cfg.Request.Web {
 		//TODO: remove second arg
 		return grpc.NewWebClient(addr, cfg.Server.Reflection, false, "", "", "", grpc.Headers(cfg.Request.Header)), nil

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -188,7 +188,13 @@ func (r *REPL) printSplash(p string) {
 }
 
 func (r *REPL) makePrefix() string {
-	p := fmt.Sprintf("%s:%s> ", r.serverCfg.Host, r.serverCfg.Port)
+	var p string
+	if strings.HasPrefix(r.serverCfg.Host, "unix://") {
+		p = fmt.Sprintf("%s> ", r.serverCfg.Host)
+	} else {
+		p = fmt.Sprintf("%s:%s> ", r.serverCfg.Host, r.serverCfg.Port)
+	}
+
 	dsn := usecase.GetDomainSourceName()
 	if dsn != "" {
 		p = fmt.Sprintf("%s@%s", dsn, p)


### PR DESCRIPTION
UNIX sockets are already supported by google.golang.org/grpc, it is only required to omit the port to be able to use them