### PR TITLE
add support for unix domain sockets

### DIFF
--- a/mode/common.go
+++ b/mode/common.go
@@ -13,7 +13,13 @@ import (
 )
 
 func newGRPCClient(cfg *config.Config) (grpc.Client, error) {
-	addr := fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port)
+	addr := cfg.Server.Host
+
+	// as long as the address doesn't start with unix, also add the port.
+	if !strings.HasPrefix(cfg.Server.Host, "unix://") {
+		addr = fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port)
+	}
+
 	if cfg.Request.Web {
 		//TODO: remove second arg
 		return grpc.NewWebClient(addr, cfg.Server.Reflection, false, "", "", "", grpc.Headers(cfg.Request.Header)), nil


### PR DESCRIPTION
grpc.NewClient already supports connecting to unix domain sockets, and accepts a string anyways.

As a quick fix, detect the `address` starting with `unix://` and don't add the port.

In the long term, we might want to deprecate `host` and `port` cmdline args in favor of a single `address` arg.