### PR TITLE
Small fixes.

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -104,7 +104,7 @@ func newOldCommand(flags *flags, ui cui.UI) *command {
 			}
 
 			defer func() {
-				if err == nil {
+				if err != nil {
 					ui.Warn("evans: deprecated usage, please use sub-commands. see `evans -h` for more details.")
 				}
 			}()

--- a/repl/completer.go
+++ b/repl/completer.go
@@ -1,7 +1,6 @@
 package repl
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -144,7 +143,7 @@ func newCompleter(cmds map[string]commander) *completer {
 				for _, svc := range svcs {
 					rpcs, err := usecase.ListRPCs(svc)
 					if err != nil {
-						panic(fmt.Sprintf("ListRPCs must not return an error, but got '%s'", err))
+						return nil
 					}
 					for _, rpc := range rpcs {
 						if _, found := encountered[rpc.RequestType.Name]; !found {


### PR DESCRIPTION
There are some issues with simple fixes:-
- Printing warnings : ```"evans: deprecated usage, please use sub-commands. see `evans -h` for more details."```
- Panic when ```"ListRPCs must not return an error, but got '%s'", err"```, it shouldn't panic, instead just return nil.

Imagine this scenario:
```
- pb/
- proto/
    - user.proto
    - main_service.proto
``` 

### user.proto
```proto
syntax = "proto3"; // use the latest syntax

package pb; // just to group things

import "google/protobuf/timestamp.proto";

option go_package = "github.com/AYehia0/go-bk-mst/pb";

// the main user
message User {
    // <data_type> <name> = <id>
    string username = 1;
    string email = 2;
    string full_name = 3;
    google.protobuf.Timestamp password_changed_at = 4;
    google.protobuf.Timestamp created_at = 5;
}

// create user
message CreateUserResponse {
    User user = 1;
}
message CreateUserRequest {
    string username = 1;
    string email = 2;
    string full_name = 3;
    string password = 4;
}

// login user
message LoginUserResponse {
    User user = 1;
    string access_token = 2;
    string refresh_token = 3;
    string session_id = 4;
    google.protobuf.Timestamp access_token_expires_at = 5;
    google.protobuf.Timestamp refresh_token_expires_at = 6;
}
message LoginUserRequest {
    string username = 1;
    string password = 2;
}
```
### the main service
```proto
syntax = "proto3";

import "user.proto";

package pb;

option go_package = "github.com/AYehia0/go-bk-mst/pb";

service SimpleBank {
    rpc CreateUser (CreateUserRequest) returns (CreateUserResponse) {}
    rpc LoginUser (LoginUserRequest) returns (LoginUserResponse) {}
}
```

It panics : ```ListRPCs must not return an error, but got 'failed to resolve service pb.SimpleBank: proto: could not resolve import "user.proto": not found'```


### Specs
- Os:  `Arch Linux`
- Terminal: `Kitty`
- protoc: `libprotoc 24.4`
- protoc-gen-go: `protoc-gen-go v1.28.1`
