### PR TITLE
refactor: delete idl dependency and delete unused errors

### DIFF
--- a/idl/idl.go
+++ b/idl/idl.go
@@ -15,16 +15,6 @@ import (
 	"github.com/ktr0731/evans/grpc"
 )
 
-var (
-	ErrPackageUnselected = errors.New("package unselected")
-	ErrServiceUnselected = errors.New("service unselected")
-
-	ErrUnknownPackageName = errors.New("unknown package name")
-	ErrUnknownServiceName = errors.New("unknown service name")
-	ErrUnknownRPCName     = errors.New("unknown RPC name")
-	ErrUnknownSymbol      = errors.New("unknown symbol")
-)
-
 // Spec represents the interface specification from loaded IDL files.
 type Spec interface {
 	// ServiceNames returns all service names the spec loaded.

--- a/repl/commands.go
+++ b/repl/commands.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ktr0731/evans/format"
 	"github.com/ktr0731/evans/format/curl"
-	"github.com/ktr0731/evans/idl"
 	"github.com/ktr0731/evans/usecase"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -94,9 +93,9 @@ func (c *serviceCommand) Validate(args []string) error {
 func (c *serviceCommand) Run(_ io.Writer, args []string) error {
 	err := usecase.UseService(args[0])
 	switch errors.Cause(err) {
-	case idl.ErrPackageUnselected:
+	case usecase.ErrPackageUnselected:
 		return errors.New("package unselected. please execute 'package' command at the first")
-	case idl.ErrUnknownServiceName:
+	case usecase.ErrUnknownServiceName:
 		return errors.Errorf("unknown service name '%s'", args[0])
 	}
 	return err


### PR DESCRIPTION
### Fix these issues: 
- `case idl.ErrPackageUnselected:` `case idl.ErrUnknownServiceName:` are unreachable. 
- Errors in idl package such as `ErrPackageUnselected` are duplicated with `usecase` package and it seems seems unused except unreachale case. 


### Changes

Error message changed when specify service without selecting package or speficy invalid service name. 

Prepare
```
cp repl/testdata/test.proto repl/testdata/test2.proto
sed -i -e 's/package api;/package api2;/g'  repl/testdata/test2.proto # set different package name
```


On master branch
```
$ go run main.go --proto repl/testdata/test.proto
...
127.0.0.1:50051> service hoge
command service: unknown service name

$ go run main.go --proto repl/testdata/test.proto --proto repl/testdata/test2.proto
...
127.0.0.1:50051> service api.Example
command service: package unselected
```

On this branch, 

```
$ go run main.go --proto repl/testdata/test.proto
...
api.Example@127.0.0.1:50051> service hoge
command service: unknown service name 'hoge'

$ go run main.go --proto repl/testdata/test.proto --proto repl/testdata/test2.proto
...
127.0.0.1:50051> service api.Example
command service: package unselected. please execute 'package' command at the first
```

